### PR TITLE
fix: dispose leaks, suppress known warning, update license

### DIFF
--- a/BBDown.Core/Parser.cs
+++ b/BBDown.Core/Parser.cs
@@ -240,7 +240,7 @@ public static partial class Parser
                     }
                 }
             }
-            catch (Exception) { /* non-critical metadata, ignore */ }
+            catch (Exception e) { LogDebug("杜比音频解析失败: {0}", e.Message); }
 
             //处理Hi-Res无损
             try
@@ -257,7 +257,7 @@ public static partial class Parser
                     }
                 }
             }
-            catch (Exception) { /* non-critical metadata, ignore */ }
+            catch (Exception e) { LogDebug("Hi-Res音频解析失败: {0}", e.Message); }
 
             if (video != null)
             {

--- a/BBDown.Core/Util/HTTPUtil.cs
+++ b/BBDown.Core/Util/HTTPUtil.cs
@@ -62,7 +62,7 @@ public static class HTTPUtil
         webRequest.Headers.Connection.Clear();
 
         LogDebug("获取网页内容: Url: {0}, Headers: {1}", url, webRequest.Headers);
-        var webResponse = (await AppHttpClient.SendAsync(webRequest, HttpCompletionOption.ResponseHeadersRead)).EnsureSuccessStatusCode();
+        using var webResponse = (await AppHttpClient.SendAsync(webRequest, HttpCompletionOption.ResponseHeadersRead)).EnsureSuccessStatusCode();
 
         string htmlCode = await webResponse.Content.ReadAsStringAsync();
         LogDebug("Response: {0}", htmlCode);
@@ -84,7 +84,7 @@ public static class HTTPUtil
                 webRequest.Headers.Connection.Clear();
 
                 LogDebug("获取网页重定向地址(method={1}): Url: {0}", url, method);
-                var webResponse = (await AppHttpClient.SendAsync(webRequest, HttpCompletionOption.ResponseHeadersRead)).EnsureSuccessStatusCode();
+                using var webResponse = (await AppHttpClient.SendAsync(webRequest, HttpCompletionOption.ResponseHeadersRead)).EnsureSuccessStatusCode();
                 string location = webResponse.RequestMessage?.RequestUri?.AbsoluteUri ?? url;
                 LogDebug("Location: {0}", location);
                 return location;
@@ -124,7 +124,7 @@ public static class HTTPUtil
             request.Headers.TryAddWithoutValidation("grpc-encoding", "gzip");
         }
 
-        HttpResponseMessage response = await AppHttpClient.SendAsync(request);
+        using HttpResponseMessage response = await AppHttpClient.SendAsync(request);
         byte[] bytes = await response.Content.ReadAsByteArrayAsync();
 
         return bytes;

--- a/BBDown/BBDown.csproj
+++ b/BBDown/BBDown.csproj
@@ -12,6 +12,8 @@
     <ToolCommandName>BBDown</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <NoWarn>$(NoWarn);IL3050</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/BBDown/BBDownLoginUtil.cs
+++ b/BBDown/BBDownLoginUtil.cs
@@ -25,7 +25,8 @@ internal static class BBDownLoginUtil
         {
             Log("获取登录地址...");
             string loginUrl = "https://passport.bilibili.com/x/passport-login/web/qrcode/generate?source=main-fe-header";
-            string url = JsonDocument.Parse(await HTTPUtil.GetWebSourceAsync(loginUrl)).RootElement.GetProperty("data").GetProperty("url").ToString();
+            using var loginDoc = JsonDocument.Parse(await HTTPUtil.GetWebSourceAsync(loginUrl));
+            string url = loginDoc.RootElement.GetProperty("data").GetProperty("url").GetString()!;
             string qrcodeKey = GetQueryString("qrcode_key", url);
             //Log(oauthKey);
             //Log(url);
@@ -43,7 +44,8 @@ internal static class BBDownLoginUtil
             {
                 await Task.Delay(1000);
                 string w = await GetLoginStatusAsync(qrcodeKey);
-                int code = JsonDocument.Parse(w).RootElement.GetProperty("data").GetProperty("code").GetInt32();
+                using var pollDoc = JsonDocument.Parse(w);
+                int code = pollDoc.RootElement.GetProperty("data").GetProperty("code").GetInt32();
                 if (code == 86038)
                 {
                     LogColor("二维码已过期, 请重新执行登录指令.");
@@ -63,7 +65,8 @@ internal static class BBDownLoginUtil
                 }
                 else
                 {
-                    string cc = JsonDocument.Parse(w).RootElement.GetProperty("data").GetProperty("url").ToString();
+                    using var successDoc = JsonDocument.Parse(w);
+                    string cc = successDoc.RootElement.GetProperty("data").GetProperty("url").GetString()!;
                     Log("登录成功: SESSDATA=" + GetQueryString("SESSDATA", cc));
                     //导出cookie, 转义英文逗号 否则部分场景会出问题
                     var cookiePath = Path.Combine(Program.APP_DIR, "BBDown.data");
@@ -87,8 +90,9 @@ internal static class BBDownLoginUtil
             Log("获取登录地址...");
             byte[] responseArray = await (await HTTPUtil.AppHttpClient.PostAsync(loginUrl, new FormUrlEncodedContent(parameters.ToDictionary()))).Content.ReadAsByteArrayAsync();
             string web = Encoding.UTF8.GetString(responseArray);
-            string url = JsonDocument.Parse(web).RootElement.GetProperty("data").GetProperty("url").ToString();
-            string authCode = JsonDocument.Parse(web).RootElement.GetProperty("data").GetProperty("auth_code").ToString();
+            using var authDoc = JsonDocument.Parse(web);
+            string url = authDoc.RootElement.GetProperty("data").GetProperty("url").GetString()!;
+            string authCode = authDoc.RootElement.GetProperty("data").GetProperty("auth_code").GetString()!;
             Log("生成二维码...");
             QRCodeGenerator qrGenerator = new();
             QRCodeData qrCodeData = qrGenerator.CreateQrCode(url, QRCodeGenerator.ECCLevel.Q);
@@ -106,7 +110,8 @@ internal static class BBDownLoginUtil
                 await Task.Delay(1000);
                 responseArray = await (await HTTPUtil.AppHttpClient.PostAsync(pollUrl, new FormUrlEncodedContent(parameters.ToDictionary()))).Content.ReadAsByteArrayAsync();
                 web = Encoding.UTF8.GetString(responseArray);
-                string code = JsonDocument.Parse(web).RootElement.GetProperty("code").ToString();
+                using var pollDoc2 = JsonDocument.Parse(web);
+                string code = pollDoc2.RootElement.GetProperty("code").GetString()!;
                 if (code == "86038")
                 {
                     LogColor("二维码已过期, 请重新执行登录指令.");
@@ -118,7 +123,8 @@ internal static class BBDownLoginUtil
                 }
                 else
                 {
-                    string cc = JsonDocument.Parse(web).RootElement.GetProperty("data").GetProperty("access_token").ToString();
+                    using var successDoc2 = JsonDocument.Parse(web);
+                    string cc = successDoc2.RootElement.GetProperty("data").GetProperty("access_token").GetString()!;
                     Log("登录成功: AccessToken=" + cc);
                     //导出cookie
                     var tvTokenPath = Path.Combine(Program.APP_DIR, "BBDownTV.data");

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2020 nilaoda
+Copyright (c) 2025 AliverAnme
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
- BBDown.csproj: add ImplicitUsings for consistency; suppress IL3050 (known Spectre.Console.Cli AOT limitation)
- Parser.cs: add LogDebug in Dolby/Hi-Res fallback catch blocks
- HTTPUtil.cs: add 'using' to HttpResponseMessage in GetWebSourceAsync, GetWebLocationAsync, GetPostResponseAsync to prevent socket exhaustion
- BBDownLoginUtil.cs: dispose all JsonDocument instances to release ArrayPool-rented buffers
- LICENSE: add Copyright (c) 2025 AliverAnme alongside original author