### PR TITLE
fix: async, cross-platform, and logging issues per review

### DIFF
--- a/BBDown.Core/DanmakuUtil.cs
+++ b/BBDown.Core/DanmakuUtil.cs
@@ -185,7 +185,7 @@ public static class DanmakuUtil
             }
             catch (Exception e)
             {
-                Log(e.Message);
+                LogDebug("弹幕时间解析失败: {0}", e.Message);
             }
             FontSize = attrs[2];
             try

--- a/BBDown/BBDownApiServer.cs
+++ b/BBDown/BBDownApiServer.cs
@@ -45,10 +45,28 @@ public class BBDownApiServer
         app = builder.Build();
         app.UseCors("AllowAnyOrigin");
         var taskStatusApi = app.MapGroup("/get-tasks");
-        taskStatusApi.MapGet("/", handler: () => { lock (_taskLock) { return Results.Json(new DownloadTaskCollection(runningTasks, finishedTasks), AppJsonSerializerContext.Default.DownloadTaskCollection); } });
-        taskStatusApi.MapGet("/running", handler: () => { lock (_taskLock) { return Results.Json(runningTasks, AppJsonSerializerContext.Default.ListDownloadTask); } });
-        taskStatusApi.MapGet("/finished", handler: () => { lock (_taskLock) { return Results.Json(finishedTasks, AppJsonSerializerContext.Default.ListDownloadTask); } });
-        taskStatusApi.MapGet("/{id}", (string id) =>
+        taskStatusApi.MapGet("/", handler: () =>
+        {
+            lock (_taskLock)
+            {
+                return Results.Json(new DownloadTaskCollection(runningTasks, finishedTasks), AppJsonSerializerContext.Default.DownloadTaskCollection);
+            }
+        });
+        taskStatusApi.MapGet("/running", handler: () =>
+        {
+            lock (_taskLock)
+            {
+                return Results.Json(runningTasks, AppJsonSerializerContext.Default.ListDownloadTask);
+            }
+        });
+        taskStatusApi.MapGet("/finished", handler: () =>
+        {
+            lock (_taskLock)
+            {
+                return Results.Json(finishedTasks, AppJsonSerializerContext.Default.ListDownloadTask);
+            }
+        });
+        taskStatusApi.MapGet("/{id}", (string id, CancellationToken token) =>
         {
             DownloadTask? task, rtask;
             lock (_taskLock)
@@ -63,11 +81,10 @@ public class BBDownApiServer
             }
             return Results.Json(task, AppJsonSerializerContext.Default.DownloadTask);
         });
-        app.MapPost("/add-task", (MyOptionBindingResult<ServeRequestOptions> bindingResult) =>
+        app.MapPost("/add-task", (MyOptionBindingResult<ServeRequestOptions> bindingResult, CancellationToken token) =>
         {
             if (!bindingResult.IsValid)
             {
-                //var exception = bindingResult.Exception;
                 return Results.BadRequest("输入有误");
             }
             var req = bindingResult.Result!;
@@ -75,9 +92,21 @@ public class BBDownApiServer
             return Results.Ok();
         });
         var finishedRemovalApi = app.MapGroup("remove-finished");
-        finishedRemovalApi.MapGet("/", () => { lock (_taskLock) { finishedTasks.RemoveAll(t => true); } return Results.Ok(); });
-        finishedRemovalApi.MapGet("/failed", () => { lock (_taskLock) { finishedTasks.RemoveAll(t => !t.IsSuccessful); } return Results.Ok(); });
-        finishedRemovalApi.MapGet("/{id}", (string id) => { lock (_taskLock) { finishedTasks.RemoveAll(t => t.Aid == id); } return Results.Ok(); });
+        finishedRemovalApi.MapGet("/", () =>
+        {
+            lock (_taskLock) { finishedTasks.RemoveAll(t => true); }
+            return Results.Ok();
+        });
+        finishedRemovalApi.MapGet("/failed", () =>
+        {
+            lock (_taskLock) { finishedTasks.RemoveAll(t => !t.IsSuccessful); }
+            return Results.Ok();
+        });
+        finishedRemovalApi.MapGet("/{id}", (string id) =>
+        {
+            lock (_taskLock) { finishedTasks.RemoveAll(t => t.Aid == id); }
+            return Results.Ok();
+        });
     }
 
     public void Run(string url)

--- a/BBDown/Program.cs
+++ b/BBDown/Program.cs
@@ -390,11 +390,9 @@ partial class Program
                         if (myOption.SubOnly && File.Exists(s.path) && File.ReadAllText(s.path) != "")
                         {
                             var _outSubPath = FormatSavePath(savePathFormat, title, null, null, p, pagesCount, apiType, pubTime);
-                            if (_outSubPath.Contains('/'))
-                            {
-                                if (!Directory.Exists(_outSubPath.Split('/').First()))
-                                    Directory.CreateDirectory(_outSubPath.Split('/').First());
-                            }
+                            var dir = Path.GetDirectoryName(_outSubPath);
+                            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+                                Directory.CreateDirectory(dir);
                             _outSubPath = Path.ChangeExtension(_outSubPath, $".{s.lan}.srt");
                             File.Move(s.path, _outSubPath, true);
                         }
@@ -638,7 +636,7 @@ partial class Program
                     LogError("合并失败"); return;
                 }
                 Log("清理临时文件...");
-                Thread.Sleep(200);
+                await Task.Delay(200);
                 if (parsedResult.VideoTracks.Any()) File.Delete(videoPath);
                 if (parsedResult.AudioTracks.Any()) File.Delete(audioPath);
                 if (p.points.Any()) File.Delete(Path.Combine(Path.GetDirectoryName(string.IsNullOrEmpty(videoPath) ? audioPath : videoPath)!, "chapters"));
@@ -730,7 +728,7 @@ partial class Program
                     LogError("合并失败"); return;
                 }
                 Log("清理临时文件...");
-                Thread.Sleep(200);
+                await Task.Delay(200);
                 if (parsedResult.VideoTracks.Count != 0) File.Delete(videoPath);
                 foreach (var s in subtitleInfo) File.Delete(s.path);
                 foreach (var a in audioMaterial) File.Delete(a.path);


### PR DESCRIPTION
- Program.cs: replace Thread.Sleep(200) with await Task.Delay(200) in async cleanup methods to stop blocking thread-pool threads
- Program.cs: subtitle-only directory creation now uses Path.GetDirectoryName() for cross-platform path support
- BBDownApiServer.cs: reformat multi-statement-inline lambdas into multi-line for readability; add CancellationToken to /{id} endpoint and /add-task handler (ASP.NET Core best practice)
- DanmakuUtil.cs: replace bare Log(e.Message) with LogDebug so danmaku parse failures only appear in debug mode

## 描述
<!-- 一句话描述这个 PR 做了什么 -->
This pull request includes several improvements and refactorings to API server endpoints, file operations, and logging throughout the codebase. The main themes are improved code readability and maintainability, better async handling, and more robust file/directory operations.

API server improvements:
* Refactored the API endpoint handlers in `BBDownApiServer.cs` to use multi-line lambda expressions for better readability and maintainability, and added `CancellationToken` support to relevant endpoints. [[1]](diffhunk://#diff-0a4ed6c1020a562483a125813d8eaf38822f90af85d64497f416fa632dfccb97L48-R69) [[2]](diffhunk://#diff-0a4ed6c1020a562483a125813d8eaf38822f90af85d64497f416fa632dfccb97L66-R109)

File and directory handling:
* Improved directory creation logic in subtitle-only mode in `Program.cs` by using `Path.GetDirectoryName` and checking for non-empty directory names, making the code more robust and platform-independent.

Async and await enhancements:
* Replaced `Thread.Sleep` with `await Task.Delay` in two places in `Program.cs` to avoid blocking threads and to improve async flow. [[1]](diffhunk://#diff-f3c19b2f8c1263419874b39fdb0d8ee25d6bf553d4e7487eecb4069b078132a3L641-R639) [[2]](diffhunk://#diff-f3c19b2f8c1263419874b39fdb0d8ee25d6bf553d4e7487eecb4069b078132a3L733-R731)

Logging improvements:
* Improved error logging in `DanmakuUtil.cs` by providing a more descriptive message when parsing fails.
