### PR TITLE
fix: KeyNotFound and First() runtime exceptions

### DIFF
--- a/BBDown.Core/Fetcher/FavListFetcher.cs
+++ b/BBDown.Core/Fetcher/FavListFetcher.cs
@@ -23,7 +23,11 @@ public class FavListFetcher : IFetcher
         {
             var favListApi = $"https://api.bilibili.com/x/v3/fav/folder/created/list-all?up_mid={mid}";
             using var favDoc = JsonDocument.Parse(await GetWebSourceAsync(favListApi));
-            favId = favDoc.RootElement.GetProperty("data").GetProperty("list").EnumerateArray().First().GetProperty("id").ToString();
+            var list = favDoc.RootElement.GetProperty("data").GetProperty("list").EnumerateArray();
+            var firstFav = list.FirstOrDefault();
+            if (firstFav.ValueKind == System.Text.Json.JsonValueKind.Undefined)
+                throw new Exception("该用户没有创建收藏夹");
+            favId = firstFav.GetProperty("id").ToString();
         }
 
         int pageSize = 20;

--- a/BBDown.Core/Parser.cs
+++ b/BBDown.Core/Parser.cs
@@ -129,7 +129,7 @@ public static partial class Parser
                             {
                                 dur = pDur,
                                 id = videoId,
-                                dfn = Config.qualitys[videoId],
+                                dfn = Config.qualitys.GetValueOrDefault(videoId, $"未知({videoId})"),
                                 bandwidth = Convert.ToInt64(dashVideo.GetProperty("bandwidth").ToString()) / 1000,
                                 baseUrl = urlList.FirstOrDefault(i => !BaseUrlRegex().IsMatch(i), urlList.First()),
                                 codecs = GetVideoCodec(dashVideo.GetProperty("codecid").ToString()),
@@ -273,7 +273,7 @@ public static partial class Parser
                     {
                         dur = pDur,
                         id = videoId,
-                        dfn = Config.qualitys[videoId],
+                        dfn = Config.qualitys.GetValueOrDefault(videoId, $"未知({videoId})"),
                         bandwidth = Convert.ToInt64(node.GetProperty("bandwidth").ToString()) / 1000,
                         baseUrl = urlList.FirstOrDefault(i => !BaseUrlRegex().IsMatch(i), urlList.First()),
                         codecs = GetVideoCodec(node.GetProperty("codecid").ToString()),
@@ -426,7 +426,7 @@ public static partial class Parser
             Video v = new()
             {
                 id = quality,
-                dfn = Config.qualitys[quality],
+                dfn = Config.qualitys.GetValueOrDefault(quality, $"未知({quality})"),
                 baseUrl = url,
                 codecs = GetVideoCodec(videoCodecid),
                 dur = (int)length / 1000,

--- a/BBDown/Utilities/BBDownUtil.cs
+++ b/BBDown/Utilities/BBDownUtil.cs
@@ -158,7 +158,11 @@ static partial class BBDownUtil
                 Regex regex = StateRegex();
                 string json = regex.Match(web).Groups[1].Value;
                 using var jDoc = JsonDocument.Parse(json);
-                string epId = jDoc.RootElement.GetProperty("epList").EnumerateArray().First().GetProperty("id").ToString();
+                var epList = jDoc.RootElement.GetProperty("epList").EnumerateArray();
+                var firstEp = epList.FirstOrDefault();
+                if (firstEp.ValueKind == System.Text.Json.JsonValueKind.Undefined)
+                    throw new Exception("未找到任何分P信息");
+                string epId = firstEp.GetProperty("id").ToString();
                 avid = $"ep:{epId}";
             }
         }
@@ -274,7 +278,11 @@ static partial class BBDownUtil
         string api = $"https://api.bilibili.com/pugv/view/web/season?season_id={ssid}";
         string json = await GetWebSourceAsync(api);
         using var jDoc = JsonDocument.Parse(json);
-        string epId = jDoc.RootElement.GetProperty("data").GetProperty("episodes").EnumerateArray().First().GetProperty("id").ToString();
+        var episodes = jDoc.RootElement.GetProperty("data").GetProperty("episodes").EnumerateArray();
+        var firstEp = episodes.FirstOrDefault();
+        if (firstEp.ValueKind == System.Text.Json.JsonValueKind.Undefined)
+            throw new Exception("未找到课程分P信息");
+        string epId = firstEp.GetProperty("id").ToString();
         return epId;
     }
 
@@ -283,7 +291,11 @@ static partial class BBDownUtil
         string api = $"https://{Core.Config.EPHOST}/pgc/view/web/season?season_id={ssId}";
         string json = await GetWebSourceAsync(api);
         using var jDoc = JsonDocument.Parse(json);
-        string epId = jDoc.RootElement.GetProperty("result").GetProperty("episodes").EnumerateArray().First().GetProperty("id").ToString();
+        var episodes = jDoc.RootElement.GetProperty("result").GetProperty("episodes").EnumerateArray();
+        var firstEp = episodes.FirstOrDefault();
+        if (firstEp.ValueKind == System.Text.Json.JsonValueKind.Undefined)
+            throw new Exception("未找到番剧分P信息");
+        string epId = firstEp.GetProperty("id").ToString();
         return epId;
     }
 


### PR DESCRIPTION
- Parser.cs: replace Config.qualitys[videoId] with GetValueOrDefault to avoid KeyNotFoundException when Bili API returns unknown quality IDs
- BBDownUtil.cs: replace .First() with .FirstOrDefault() + empty-check in GetAvIdAsync, GetEpidBySSIdAsync, GetEpIdByBangumiSSIdAsync
- FavListFetcher.cs: replace .First() with .FirstOrDefault() + empty-check when looking up default favorites folder

All three cases now throw descriptive Exception messages instead of generic InvalidOperationException/KeyNotFoundException.

Build: 0 Warning(s), 0 Error(s)