### PR TITLE
Fix/path getdirectory null

### DIFF
--- a/BBDown.Core/AppHelper.cs
+++ b/BBDown.Core/AppHelper.cs
@@ -54,6 +54,10 @@ static class AppHelper
     /// <returns></returns>
     public static async Task<string> DoReqAsync(string aid, string cid, string epId, string qn, bool bangumi, string encoding, string appkey = "")
     {
+        static long ParseId(string value, string name) =>
+            long.TryParse(value, out var result)
+                ? result
+                : throw new ArgumentException($"{name} 必须是有效的数字 ID，当前值: '{value}'");
 
         var headers = GetHeader(appkey);
         LogDebug("App-Req-Headers: {0}", JsonSerializer.Serialize(headers, JsonContext.Default.DictionaryStringString));
@@ -63,12 +67,12 @@ static class AppHelper
         {
             if (!(string.IsNullOrEmpty(encoding) || encoding == "HEVC"))
                 LogWarn("APP的番剧不支持 HEVC 以外的编码");
-            var body = GetPayload(Convert.ToInt64(epId), Convert.ToInt64(cid), Convert.ToInt64(qn), PlayViewReq.Types.CodeType.Code265);
+            var body = GetPayload(ParseId(epId, nameof(epId)), ParseId(cid, nameof(cid)), ParseId(qn, nameof(qn)), PlayViewReq.Types.CodeType.Code265);
             data = await GetPostResponseAsync(API2, body, headers);
         }
         else
         {
-            var body = GetPayload(Convert.ToInt64(aid), Convert.ToInt64(cid), Convert.ToInt64(qn), GetVideoCodeType(encoding));
+            var body = GetPayload(ParseId(aid, nameof(aid)), ParseId(cid, nameof(cid)), ParseId(qn, nameof(qn)), GetVideoCodeType(encoding));
             data = await GetPostResponseAsync(API, body, headers);
         }
         var resp = new MessageParser<PlayViewReply>(() => new PlayViewReply()).ParseFrom(ReadMessage(data));

--- a/BBDown/Infrastructure/BBDownMuxer.cs
+++ b/BBDown/Infrastructure/BBDownMuxer.cs
@@ -62,7 +62,10 @@ static partial class BBDownMuxer
         if (points != null && points.Any())
         {
             var meta = GetMp4boxMetaString(points);
-            var metaFile = Path.Combine(Path.GetDirectoryName(string.IsNullOrEmpty(videoPath) ? audioPath : videoPath)!, "chapters");
+            var baseDir = Path.GetDirectoryName(string.IsNullOrEmpty(videoPath) ? audioPath : videoPath);
+            if (string.IsNullOrEmpty(baseDir))
+                baseDir = ".";
+            var metaFile = Path.Combine(baseDir, "chapters");
             File.WriteAllText(metaFile, meta);
             inputArg.Append($" -chap  \"{metaFile}\"  ");
         }
@@ -167,7 +170,10 @@ static partial class BBDownMuxer
         if (points != null && points.Any())
         {
             var meta = GetFFmpegMetaString(points);
-            var metaFile = Path.Combine(Path.GetDirectoryName(string.IsNullOrEmpty(videoPath) ? audioPath : videoPath)!, "chapters");
+            var baseDir = Path.GetDirectoryName(string.IsNullOrEmpty(videoPath) ? audioPath : videoPath);
+            if (string.IsNullOrEmpty(baseDir))
+                baseDir = ".";
+            var metaFile = Path.Combine(baseDir, "chapters");
             File.WriteAllText(metaFile, meta);
             inputArg.Append($"-i \"{metaFile}\" -map_chapters {inputCount} ");
         }


### PR DESCRIPTION
This pull request improves input validation and file handling robustness in the codebase. The main changes include adding stricter parsing for numeric IDs to prevent invalid inputs and enhancing the handling of file paths when generating chapter metadata files, ensuring that files are always written to a valid directory.

**Input Validation Improvements:**

* Introduced a `ParseId` helper method in `AppHelper.cs` to strictly validate that `aid`, `cid`, `epId`, and `qn` are valid numeric IDs, throwing a descriptive exception if not, and replaced all previous `Convert.ToInt64` calls with this method. [[1]](diffhunk://#diff-2759df75e21a9dfbe676de45ad229a7c449b9fac64a739c3745b5b07d9d1b850R57-R60) [[2]](diffhunk://#diff-2759df75e21a9dfbe676de45ad229a7c449b9fac64a739c3745b5b07d9d1b850L66-R75)

**File Path Handling Enhancements:**

* Updated both `MuxByMp4box` and `MuxAV` methods in `BBDownMuxer.cs` to check if the base directory for chapter metadata files is null or empty, defaulting to the current directory `"."` if necessary, to prevent errors when writing chapter files. [[1]](diffhunk://#diff-889ff5b57a5ae7149be4a0e9b330cdac66eb1be8d6a2e4a90ce9c32d4e62d255L65-R68) [[2]](diffhunk://#diff-889ff5b57a5ae7149be4a0e9b330cdac66eb1be8d6a2e4a90ce9c32d4e62d255L170-R176)