### PR TITLE
refactor: extract GetValidFileName to BBDown.Core.Util.PathUtil

### DIFF
--- a/BBDown.Core/Fetcher/SpaceVideoFetcher.cs
+++ b/BBDown.Core/Fetcher/SpaceVideoFetcher.cs
@@ -2,6 +2,7 @@
 using System.Text.Json;
 using static BBDown.Core.Util.HTTPUtil;
 using static BBDown.Core.Logger;
+using static BBDown.Core.Util.PathUtil;
 
 namespace BBDown.Core.Fetcher;
 
@@ -56,20 +57,5 @@ pause");
             urls.Add($"https://www.bilibili.com/video/av{page.GetProperty("aid")}");
         }
         return urls;
-    }
-
-    private static string GetValidFileName(string input, string re = "_", bool filterSlash = false)
-    {
-        string title = input;
-        foreach (char invalidChar in Path.GetInvalidFileNameChars())
-        {
-            title = title.Replace(invalidChar.ToString(), re);
-        }
-        if (filterSlash)
-        {
-            title = title.Replace("/", re);
-            title = title.Replace("\\", re);
-        }
-        return title;
     }
 }

--- a/BBDown.Core/Util/PathUtil.cs
+++ b/BBDown.Core/Util/PathUtil.cs
@@ -1,0 +1,33 @@
+using System.IO;
+
+namespace BBDown.Core.Util;
+
+public static class PathUtil
+{
+    private static readonly char[] InvalidChars = "34,60,62,124,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,58,42,63,92,47"
+        .Split(',').Select(s => (char)byte.Parse(s)).ToArray();
+
+    private static readonly HashSet<string> ReservedNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "CON", "PRN", "AUX", "NUL",
+        "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+        "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+    };
+
+    public static string GetValidFileName(string input, string re = "_", bool filterSlash = false)
+    {
+        string title = input;
+        foreach (char invalidChar in InvalidChars)
+        {
+            title = title.Replace(invalidChar.ToString(), re);
+        }
+        if (filterSlash)
+        {
+            title = title.Replace("/", re);
+            title = title.Replace("\\", re);
+        }
+        if (ReservedNames.Contains(title))
+            title = "_" + title;
+        return title;
+    }
+}

--- a/BBDown/Utilities/BBDownUtil.cs
+++ b/BBDown/Utilities/BBDownUtil.cs
@@ -362,34 +362,8 @@ static partial class BBDownUtil
         return res;
     }
 
-    private static readonly char[] InvalidChars = "34,60,62,124,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,58,42,63,92,47"
-        .Split(',').Select(s => (char)byte.Parse(s)).ToArray();
-
-    private static readonly HashSet<string> ReservedNames = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "CON", "PRN", "AUX", "NUL",
-        "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
-        "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
-    };
-
     public static string GetValidFileName(string input, string re = "_", bool filterSlash = false)
-    {
-        string title = input;
-
-        foreach (char invalidChar in InvalidChars)
-        {
-            title = title.Replace(invalidChar.ToString(), re);
-        }
-        if (filterSlash)
-        {
-            title = title.Replace("/", re);
-            title = title.Replace("\\", re);
-        }
-        // 检测 Windows 保留文件名，添加前缀
-        if (ReservedNames.Contains(title))
-            title = "_" + title;
-        return title;
-    }
+        => BBDown.Core.Util.PathUtil.GetValidFileName(input, re, filterSlash);
 
 
     /// <summary>


### PR DESCRIPTION
- Create new BBDown.Core/Util/PathUtil.cs with shared GetValidFileName implementation (including Windows reserved-name guard)
- BBDownUtil.cs: remove private InvalidChars/ReservedNames fields and inline implementation; now forwards to PathUtil.GetValidFileName
- SpaceVideoFetcher.cs: remove duplicated private GetValidFileName method; reference shared PathUtil via using-static

Eliminates logic drift risk between the two previously separate copies.

Build: 0 Warning(s), 0 Error(s)