### PR TITLE
fix: prevent FFmpeg/MP4Box process deadlock by consuming stdout

### DIFF
--- a/BBDown/Infrastructure/BBDownMuxer.cs
+++ b/BBDown/Infrastructure/BBDownMuxer.cs
@@ -25,15 +25,23 @@ static partial class BBDownMuxer
         p.StartInfo.Arguments = args;
         p.StartInfo.UseShellExecute = false;
         p.StartInfo.RedirectStandardError = true;
+        p.StartInfo.RedirectStandardOutput = true;
         p.StartInfo.CreateNoWindow = true;
         p.ErrorDataReceived += (_, output) =>
         {
             if (!string.IsNullOrWhiteSpace(output.Data))
                 Log(output.Data);
         };
+        p.OutputDataReceived += (_, output) =>
+        {
+            if (!string.IsNullOrWhiteSpace(output.Data))
+                LogDebug(output.Data);
+        };
         p.StartInfo.StandardErrorEncoding = Encoding.UTF8;
+        p.StartInfo.StandardOutputEncoding = Encoding.UTF8;
         p.Start();
         p.BeginErrorReadLine();
+        p.BeginOutputReadLine();
         p.WaitForExit();
         return p.ExitCode;
     }


### PR DESCRIPTION
RunExe only redirected stderr via RedirectStandardError=true and BeginErrorReadLine(), but left stdout unredirected (defaulting to parent console). This causes two issues:

1. Console pollution in API server / background mode — FFmpeg progress/status lines appear in server logs.
2. Latent deadlock risk — if code is ever changed to set RedirectStandardOutput=true without a consumer, the process will hang when its stdout buffer fills.

Fix:
- Set RedirectStandardOutput=true and add OutputDataReceived handler piping lines to LogDebug.
- Set StandardOutputEncoding=Encoding.UTF8 matching stderr.
- Call BeginOutputReadLine() alongside existing BeginErrorReadLine().

Build: 0 Warning(s), 0 Error(s)