### PR TITLE
fix: use invariant culture for string operations and dispose gRPC req…

### DIFF
--- a/BBDown.Core/Util/HTTPUtil.cs
+++ b/BBDown.Core/Util/HTTPUtil.cs
@@ -102,10 +102,10 @@ public static class HTTPUtil
     {
         LogDebug("Post to: {0}, data: {1}", Url, Convert.ToBase64String(postData));
 
-        ByteArrayContent content = new(postData);
+        using ByteArrayContent content = new(postData);
         content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/grpc");
 
-        HttpRequestMessage request = new()
+        using HttpRequestMessage request = new()
         {
             RequestUri = new Uri(Url),
             Method = HttpMethod.Post,

--- a/BBDown.Core/Util/SubUtil.cs
+++ b/BBDown.Core/Util/SubUtil.cs
@@ -18,7 +18,7 @@ public static partial class SubUtil
         if (NonCapsRegex().Match(key) is { Success: true } result)
         {
             var v = result.Value;
-            key = key.Replace(v, v.ToUpper());
+            key = key.Replace(v, v.ToUpperInvariant());
         }
 
         return key switch

--- a/BBDown/Application/Options.cs
+++ b/BBDown/Application/Options.cs
@@ -78,7 +78,7 @@ internal partial class Program
         if (myOption.EncodingPriority != null)
         {
             var encodingPriorityTemp = myOption.EncodingPriority
-                .ToUpper()
+                .ToUpperInvariant()
                 .Replace('，', ',')
                 .Replace("-", string.Empty)
                 .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
@@ -100,7 +100,7 @@ internal partial class Program
     {
         if (string.IsNullOrEmpty(myOption.DownloadDanmakuFormats)) return BBDownDanmakuFormatInfo.DefaultFormats;
 
-        var formats = myOption.DownloadDanmakuFormats.Replace("，", ",").ToLower().Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        var formats = myOption.DownloadDanmakuFormats.Replace("，", ",").ToLowerInvariant().Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
         if (formats.Any(format => !BBDownDanmakuFormatInfo.AllFormatNames.Contains(format)))
         {
             LogError($"包含不支持的下载弹幕格式：{myOption.DownloadDanmakuFormats}");
@@ -120,7 +120,7 @@ internal partial class Program
         var dfnPriority = new Dictionary<string, int>();
         if (myOption.DfnPriority != null)
         {
-            var dfnPriorityTemp = myOption.DfnPriority.Replace("，", ",").Split(',').Select(s => s.ToUpper().Trim()).Where(s => !string.IsNullOrEmpty(s));
+            var dfnPriorityTemp = myOption.DfnPriority.Replace("，", ",").Split(',').Select(s => s.ToUpperInvariant().Trim()).Where(s => !string.IsNullOrEmpty(s));
             int index = 0;
             foreach (string dfn in dfnPriorityTemp)
             {

--- a/BBDown/Application/Pages.cs
+++ b/BBDown/Application/Pages.cs
@@ -18,7 +18,7 @@ internal partial class Program
     {
         List<string>? selectedPages = null;
         List<Page> pagesInfo = vInfo.PagesInfo;
-        string selectPage = myOption.SelectPage.ToUpper().Trim().Trim(',');
+        string selectPage = myOption.SelectPage.ToUpperInvariant().Trim().Trim(',');
 
         if (string.IsNullOrEmpty(selectPage))
         {

--- a/BBDown/Models/BBDownEnums.cs
+++ b/BBDown/Models/BBDownEnums.cs
@@ -13,9 +13,9 @@ public static class BBDownDanmakuFormatInfo
 {
     // 默认
     public static BBDownDanmakuFormat[] DefaultFormats = [BBDownDanmakuFormat.Xml, BBDownDanmakuFormat.Ass];
-    public static string[] DefaultFormatsNames = DefaultFormats.Select(f => f.ToString().ToLower()).ToArray();
+    public static string[] DefaultFormatsNames = DefaultFormats.Select(f => f.ToString().ToLowerInvariant()).ToArray();
     // 可选项
-    public static string[] AllFormatNames = Enum.GetNames(typeof(BBDownDanmakuFormat)).Select(f => f.ToLower()).ToArray();
+    public static string[] AllFormatNames = Enum.GetNames(typeof(BBDownDanmakuFormat)).Select(f => f.ToLowerInvariant()).ToArray();
 
     public static BBDownDanmakuFormat FromFormatName(string formatName)
     {

--- a/BBDown/Utilities/BBDownUtil.cs
+++ b/BBDown/Utilities/BBDownUtil.cs
@@ -53,7 +53,7 @@ static partial class BBDownUtil
             {
                 avid = AvRegex().Match(input).Groups[1].Value;
             }
-            else if (input.ToLower().Contains("video/bv"))
+            else if (input.ToLowerInvariant().Contains("video/bv"))
             {
                 avid = GetAidByBV(BVRegex().Match(input).Groups[1].Value);
             }
@@ -166,13 +166,13 @@ static partial class BBDownUtil
                 avid = $"ep:{epId}";
             }
         }
-        else if (input.ToLower().StartsWith("bv"))
+        else if (input.ToLowerInvariant().StartsWith("bv"))
         {
             avid = GetAidByBV(input[3..]);
         }
-        else if (input.ToLower().StartsWith("av")) // av
+        else if (input.ToLowerInvariant().StartsWith("av")) // av
         {
-            avid = input.ToLower()[2..];
+            avid = input.ToLowerInvariant()[2..];
         }
         else if (input.StartsWith("cheese/")) // ^cheese/(ep|ss)\d+ 格式
         {
@@ -352,7 +352,7 @@ static partial class BBDownUtil
         DirectoryInfo d = new(dir);
         foreach (FileInfo fi in d.GetFiles())
         {
-            if (fi.Extension.ToUpper() == ext.ToUpper())
+            if (fi.Extension.Equals(ext, StringComparison.OrdinalIgnoreCase))
             {
                 al.Add(fi.FullName);
             }


### PR DESCRIPTION
…uests

- Replace culture-sensitive ToLower()/ToUpper() with ToLowerInvariant()/ ToUpperInvariant() or StringComparison.OrdinalIgnoreCase across 6 files. On Turkish locale systems, ToUpper("i") produces "İ" instead of "I", breaking URL parsing, file extension matching, and format name comparisons.

  Affected files:
  - BBDownEnums.cs: format name normalization
  - BBDownUtil.cs: URL detection (video/bv, bv/av prefixes), file extension comparison in GetFiles()
  - Options.cs: encoding priority, dfn priority, danmaku formats
  - Pages.cs: select-page token normalization
  - SubUtil.cs: subtitle key capitalization

- HTTPUtil.GetPostResponseAsync: add using declarations for ByteArrayContent and HttpRequestMessage to ensure proper disposal of gRPC request resources.

Build: 0 Warning(s), 0 Error(s)