### PR TITLE
fix: guard against division by zero in speed/bandwidth calculations

### DIFF
--- a/BBDown.Core/AppHelper.cs
+++ b/BBDown.Core/AppHelper.cs
@@ -103,7 +103,7 @@ static class AppHelper
                         item.StreamInfo.Quality,
                         item.DashVideo.BaseUrl,
                         item.DashVideo.BackupUrl.ToList(),
-                        (uint)(item.DashVideo.Size * 8 / (resp.VideoInfo.Timelength / 1000)),
+                        (uint)(item.DashVideo.Size * 8 / Math.Max(resp.VideoInfo.Timelength / 1000, 1)),
                         item.DashVideo.Codecid
                     ));
                 }

--- a/BBDown/Application/Download.cs
+++ b/BBDown/Application/Download.cs
@@ -422,7 +422,8 @@ internal partial class Program
                 int index = 0;
                 foreach (var v in parsedResult.VideoTracks)
                 {
-                    LogColor($"{index++}. [{v.dfn}] [{v.res}] [{v.codecs}] [{v.fps}] [~{v.size / 1024 / v.dur * 8:00} kbps] [{FormatFileSize(v.size)}]".Replace("[] ", ""), false);
+                    var kbps = v.dur > 0 ? v.size / 1024 / v.dur * 8 : 0;
+                    LogColor($"{index++}. [{v.dfn}] [{v.res}] [{v.codecs}] [{v.fps}] [~{kbps:00} kbps] [{FormatFileSize(v.size)}]".Replace("[] ", ""), false);
                     if (myOption.OnlyShowInfo)
                     {
                         clips.ForEach(Console.WriteLine);

--- a/BBDown/Infrastructure/BBDownApiServer.cs
+++ b/BBDown/Infrastructure/BBDownApiServer.cs
@@ -161,7 +161,10 @@ public class BBDownApiServer
         if (task.IsSuccessful)
         {
             task.Progress = 1f;
-            task.DownloadSpeed = (double)(task.TotalDownloadedBytes / (task.TaskFinishTime - task.TaskCreateTime));
+            var elapsed = task.TaskFinishTime - task.TaskCreateTime;
+            task.DownloadSpeed = elapsed > 0
+                ? (double)(task.TotalDownloadedBytes / elapsed)
+                : 0;
         }
         lock (_taskLock)
         {

--- a/BBDown/Infrastructure/BBDownDownloadUtil.cs
+++ b/BBDown/Infrastructure/BBDownDownloadUtil.cs
@@ -147,7 +147,7 @@ internal static class BBDownDownloadUtil
                 await RangeDownloadToTmpAsync(clip.index, url, tmp, clip.from, clip.to == -1 ? null : clip.to, (index, downloaded, _) =>
                 {
                     clipProgress[index] = downloaded;
-                    progress.Report((double)clipProgress.Values.Sum() / fileSize, clipProgress.Values.Sum());
+                    progress.Report(fileSize > 0 ? (double)clipProgress.Values.Sum() / fileSize : 0, clipProgress.Values.Sum());
                 }, true);
                 break;
             }


### PR DESCRIPTION
- BBDownApiServer.cs: DownloadSpeed calculation could throw DivideByZeroException when a task completes in under 1 second (TaskFinishTime == TaskCreateTime). Guard with elapsed > 0 check.

- BBDownDownloadUtil.cs: Parallel segment download progress report divides by fileSize; protect against 0 to avoid NaN/Infinity in progress bar.

- AppHelper.cs: bitrate calculation divides by (Timelength / 1000). If API returns 0 or garbled timelength, this throws. Use Math.Max(..., 1) to clamp denominator.

- Download.cs: video track display computes kbps as size / 1024 / dur * 8. If dur is 0 (corrupted/missing metadata), this throws. Pre-calculate with dur > 0 guard.

Build: 0 Warning(s), 0 Error(s)