### PR TITLE
chore: update CI workflow and suppress Native AOT third-party warnings

### DIFF
--- a/.github/workflows/build_latest.yml
+++ b/.github/workflows/build_latest.yml
@@ -3,7 +3,7 @@ name: Build Latest
 on: [push,workflow_dispatch]
 
 env:
-  DOTNET_SDK_VERSION: "9.0.306"
+  DOTNET_SDK_VERSION: "9.0.314"
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
@@ -44,13 +44,13 @@ jobs:
           zip ../BBDown_${{ needs.set-date.outputs.date }}_win-arm64.zip BBDown.exe
 
       - name: Upload Artifact [win-x64]
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: BBDown_win-x64
           path: BBDown_${{ needs.set-date.outputs.date }}_win-x64.zip
 
       - name: Upload Artifact [win-arm64]
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: BBDown_win-arm64
           path: BBDown_${{ needs.set-date.outputs.date }}_win-arm64.zip
@@ -118,13 +118,13 @@ jobs:
           zip ../BBDown_${{ needs.set-date.outputs.date }}_linux-arm64.zip BBDown
 
       - name: Upload Artifact [linux-x64]
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: BBDown_linux-x64
           path: BBDown_${{ needs.set-date.outputs.date }}_linux-x64.zip
 
       - name: Upload Artifact[linux-arm64]
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: BBDown_linux-arm64
           path: BBDown_${{ needs.set-date.outputs.date }}_linux-arm64.zip
@@ -154,13 +154,13 @@ jobs:
           zip ../BBDown_${{ needs.set-date.outputs.date }}_osx-arm64.zip BBDown
 
       - name: Upload Artifact [osx-x64]
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: BBDown_osx-x64
           path: BBDown_${{ needs.set-date.outputs.date }}_osx-x64.zip
 
       - name: Upload Artifact [osx-arm64]
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: BBDown_osx-arm64
           path: BBDown_${{ needs.set-date.outputs.date }}_osx-arm64.zip

--- a/BBDown/BBDown.csproj
+++ b/BBDown/BBDown.csproj
@@ -13,7 +13,7 @@
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <NoWarn>$(NoWarn);IL3050</NoWarn>
+    <NoWarn>$(NoWarn);IL3050;IL3000;IL3001;IL3002</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- .github/workflows/build_latest.yml:
  * Update DOTNET_SDK_VERSION 9.0.306 → 9.0.314
  * Update actions/upload-artifact v4 → v5 (uses Node 24 natively, eliminating deprecation notices for this action)

- BBDown.csproj:
  * Add IL3000–IL3002 to NoWarn list to suppress single-file/Native AOT compatibility warnings originating from Spectre.Console.Cli (CommandModel.GetApplicationFile → Assembly.Location). These are third-party warnings that do not affect functionality because we explicitly set SetApplicationName(BBDown) and SetApplicationVersion().

The remaining Node.js 20 deprecation notices for actions/checkout@v4 and actions/setup-dotnet@v4 are infrastructure-level warnings from GitHub's action runner migration; the workflow already sets FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true which forces these actions onto Node 24. They will fully disappear once GitHub completes the runner-side transition.

Build: 0 Warning(s), 0 Error(s)