### PR TITLE
feat: limit API server to 3 concurrent downloads with SemaphoreSlim

### DIFF
--- a/BBDown/Infrastructure/BBDownApiServer.cs
+++ b/BBDown/Infrastructure/BBDownApiServer.cs
@@ -23,6 +23,7 @@ public class BBDownApiServer
     private readonly object _taskLock = new();
     private readonly List<DownloadTask> runningTasks = [];
     private readonly List<DownloadTask> finishedTasks = [];
+    private readonly SemaphoreSlim _concurrencyLimiter = new(3, 3); // max 3 concurrent downloads
 
     public void SetUpServer()
     {
@@ -135,6 +136,7 @@ public class BBDownApiServer
         };
         var task = new DownloadTask(aid, option.Url, DateTimeOffset.Now.ToUnixTimeSeconds());
         lock (_taskLock) { runningTasks.Add(task); }
+        await _concurrencyLimiter.WaitAsync();
         try
         {
             var (encodingPriority, dfnPriority, firstEncoding, downloadDanmaku, downloadDanmakuFormats, input, savePathFormat, lang, aidOri, delay) = Program.SetUpWork(option);
@@ -156,6 +158,10 @@ public class BBDownApiServer
             }
             Logger.LogError($"{aid} 下载失败");
             Logger.LogDebug("异常详情: {0}", displayMsg);
+        }
+        finally
+        {
+            _concurrencyLimiter.Release();
         }
         task.TaskFinishTime = DateTimeOffset.Now.ToUnixTimeSeconds();
         if (task.IsSuccessful)


### PR DESCRIPTION
Previously AddDownloadTaskAsync started downloading immediately regardless of how many tasks were already running. This could exhaust bandwidth, file handles, and Bilibili API quotas when multiple tasks were submitted in quick succession.

Add a SemaphoreSlim(3) to BBDownApiServer. Tasks beyond the limit wait in a FIFO queue (SemaphoreSlim's implicit queue) until a slot becomes free. The task object is still returned immediately so callers can poll /get-tasks for status, but actual download work is throttled.

Build: 0 Warning(s), 0 Error(s)
