### PR TITLE
fix: add 30-minute timeout to FFmpeg/MP4Box muxing operations

### DIFF
--- a/BBDown/Infrastructure/BBDownMuxer.cs
+++ b/BBDown/Infrastructure/BBDownMuxer.cs
@@ -42,7 +42,12 @@ static partial class BBDownMuxer
         p.Start();
         p.BeginErrorReadLine();
         p.BeginOutputReadLine();
-        p.WaitForExit();
+        const int muxTimeoutMinutes = 30;
+        if (!p.WaitForExit(muxTimeoutMinutes * 60_000))
+        {
+            try { p.Kill(); } catch { /* ignore kill failures */ }
+            throw new TimeoutException($"{app} 混流操作超过 {muxTimeoutMinutes} 分钟未结束，已强制终止。请检查输入文件是否损坏或磁盘空间是否不足。");
+        }
         return p.ExitCode;
     }
 


### PR DESCRIPTION
RunExe previously called WaitForExit() without a timeout, meaning a stuck FFmpeg or MP4Box process (e.g., corrupted input, full disk) would hang the download task forever. In API server mode this creates 'zombie tasks' that never complete.

Add a 30-minute timeout and kill the process if it exceeds the limit, throwing a descriptive TimeoutException so the caller can mark the task as failed and surface the reason to the consumer.

Build: 0 Warning(s), 0 Error(s)