### PR TITLE
fix: M0/M1 可靠性——AsyncLocal 配置回传/超长分片/零产物成功/取消断链/直播分段/请求体上限

### DIFF
--- a/.github/workflows/build_latest.yml
+++ b/.github/workflows/build_latest.yml
@@ -182,3 +182,51 @@ jobs:
         with:
           name: BBDown_osx-arm64
           path: BBDown_${{ needs.set-date.outputs.date }}_osx-arm64.zip
+
+  # Docker 镜像构建 + serve 启动冒烟：验证 Dockerfile 能产出可运行的 AOT 镜像，
+  # 且 serve 在非回环监听下正确要求 token（默认 CMD 拒绝启动是预期行为）。
+  docker-build-smoke:
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build -t bbdown:test .
+
+      - name: Smoke test — 默认 CMD（0.0.0.0 无 token）应拒绝启动
+        run: |
+          set +e
+          output=$(docker run --rm bbdown:test 2>&1)
+          exit_code=$?
+          set -e
+          echo "exit=$exit_code"
+          echo "$output"
+          if [ $exit_code -eq 0 ]; then
+            echo "错误：非回环监听未配置 token 应拒绝启动（非零退出），实际却成功了" >&2
+            exit 1
+          fi
+          echo "$output" | grep -q "serve-token" || {
+            echo "错误：拒绝信息应提示 --serve-token，实际输出: $output" >&2
+            exit 1
+          }
+
+      - name: Smoke test — 显式 token 应正常启动并可调用 API
+        run: |
+          # 后台启动容器（serve 监听 0.0.0.0:23333 + token）
+          docker run -d --name bbdown-smoke -p 23333:23333 bbdown:test \
+            serve -l http://0.0.0.0:23333 --serve-token smoketest
+          # 等待启动（AOT 二进制直接启动，通常 1-2s）
+          for i in $(seq 1 20); do
+            if curl -sf -H "X-Serve-Token: smoketest" http://127.0.0.1:23333/get-tasks/ >/dev/null 2>&1; then
+              break
+            fi
+            sleep 1
+          done
+          # 无 token 应 401，带 token 应 200
+          code_no_token=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:23333/get-tasks/)
+          code_with_token=$(curl -s -o /dev/null -w "%{http_code}" -H "X-Serve-Token: smoketest" http://127.0.0.1:23333/get-tasks/)
+          echo "no-token=$code_no_token with-token=$code_with_token"
+          [ "$code_no_token" = "401" ] || { echo "无 token 应返回 401，实际 $code_no_token" >&2; exit 1; }
+          [ "$code_with_token" = "200" ] || { echo "带 token 应返回 200，实际 $code_with_token" >&2; exit 1; }
+          docker rm -f bbdown-smoke >/dev/null

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -50,13 +50,11 @@ jobs:
         # NuGet 官方要求显式包含传递依赖
         run: dotnet list BBDown.sln package --vulnerable --include-transitive
 
-  # 格式门禁：存量文件存在大量 CHARSET/ENDOFLINE 问题（7350 处），
-  # 硬性失败会挡死所有 PR。先用 continue-on-error 把结果暴露在 CI 日志，
-  # 待纯机械格式修复 PR（BOM→UTF-8、CRLF→LF）合入后再改为硬性门禁。
+  # 格式门禁（硬性）：此前的存量 CRLF/BOM 问题已随格式修复 PR 清理，
+  # 报告确认 dotnet format --verify-no-changes 当前通过，升级为硬性门禁防回归。
   format:
-    name: Format Check (informational)
+    name: Format Check
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 
@@ -70,6 +68,26 @@ jobs:
 
       - name: Verify formatting
         run: dotnet format BBDown.sln --verify-no-changes --no-restore
+
+  # 集成测试：真实网络访问 B 站 API，验证解析/重定向/登录检测等端到端路径。
+  # 不阻断 PR（网络抖动易误报），但必须运行并报告结果。
+  integration-test:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up dotnet
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_SDK_VERSION }}
+
+      - name: Restore
+        run: dotnet restore BBDown.sln
+
+      - name: Test (integration)
+        run: dotnet test BBDown.sln -c Release --no-build --filter "Category=Integration"
 
   # Native AOT smoke：BBDown 的 Directory.Build.props 全局 PublishAot=true，
   # 确保 PR 能产出可运行的 AOT 二进制（与 release.yml 的 linux-x64 对齐）

--- a/BBDown.Core/AppHelper.cs
+++ b/BBDown.Core/AppHelper.cs
@@ -51,7 +51,7 @@ static class AppHelper
     /// <param name="qn"></param>
     /// <param name="appkey"></param>
     /// <returns></returns>
-    public static async Task<string> DoReqAsync(string aid, string cid, string epId, string qn, bool bangumi, string encoding, string appkey = "")
+    public static async Task<string> DoReqAsync(string aid, string cid, string epId, string qn, bool bangumi, string encoding, string appkey = "", CancellationToken token = default)
     {
         static long ParseId(string value, string name) =>
             long.TryParse(value, out var result)
@@ -69,12 +69,12 @@ static class AppHelper
             if (!(string.IsNullOrEmpty(encoding) || encoding == "HEVC"))
                 Logger.LogWarn("APP的番剧不支持 HEVC 以外的编码");
             var body = GetPayload(ParseId(epId, nameof(epId)), ParseId(cid, nameof(cid)), ParseId(qn, nameof(qn)), PlayViewReq.Types.CodeType.Code265);
-            data = await HTTPUtil.GetPostResponseAsync(API2, body, headers);
+            data = await HTTPUtil.GetPostResponseAsync(API2, body, headers, token);
         }
         else
         {
             var body = GetPayload(ParseId(aid, nameof(aid)), ParseId(cid, nameof(cid)), ParseId(qn, nameof(qn)), GetVideoCodeType(encoding));
-            data = await HTTPUtil.GetPostResponseAsync(API, body, headers);
+            data = await HTTPUtil.GetPostResponseAsync(API, body, headers, token);
         }
         var resp = new MessageParser<PlayViewReply>(() => new PlayViewReply()).ParseFrom(ReadMessage(data));
 

--- a/BBDown.Core/Fetcher/FavListFetcher.cs
+++ b/BBDown.Core/Fetcher/FavListFetcher.cs
@@ -85,7 +85,13 @@ public class FavListFetcher : IFetcher
                             pagesInfo.Add(p);
                         }
                     }
-                    // 单个多P稿件失效（删除/私密/风控）不应中断整个收藏夹解析
+                    // 单个多P稿件失效（删除/私密/风控）不应中断整个收藏夹解析，
+                    // 但真正的用户取消必须向上传播中止整个流程——否则取消被吞成
+                    // "某个稿件解析失败"，批量下载会在取消信号下继续空转。
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                    {
+                        throw;
+                    }
                     catch (Exception ex) when (ex is HttpRequestException or JsonException or KeyNotFoundException
                                                   or InvalidOperationException or TaskCanceledException)
                     {

--- a/BBDown.Core/Fetcher/SpaceVideoFetcher.cs
+++ b/BBDown.Core/Fetcher/SpaceVideoFetcher.cs
@@ -29,8 +29,12 @@ public class SpaceVideoFetcher : IFetcher
     public async Task<VInfo> FetchAsync(string id, CancellationToken cancellationToken = default)
     {
         id = id[4..];
-        // 该接口按 B 站惯例需要设备标识，未登录时 Cookie 为空
-        await BuvidProvider.EnsureAsync();
+        // 该接口按 B 站惯例需要设备标识，未登录时 Cookie 为空。
+        // EnsureAsync 返回注入后的新 Cookie，由本方法在其流程内显式应用
+        // （AsyncLocal 写入不会自动回流，见 BuvidProvider 说明）——本方法后续请求
+        // 读取 Config.Current.Cookie 时才能带上 buvid3。
+        var updatedCookie = await BuvidProvider.EnsureAsync();
+        if (updatedCookie is not null) Core.Config.COOKIE_FLOW = updatedCookie;
         // using the live API can bypass w_rid
         string userInfoApi = $"https://api.live.bilibili.com/live_user/v1/Master/info?uid={id}";
         using var userDoc = JsonDocument.Parse(await HTTPUtil.GetWebSourceAsync(userInfoApi, token: cancellationToken));
@@ -89,6 +93,12 @@ public class SpaceVideoFetcher : IFetcher
                         desc = entry.Description,
                     });
                 }
+            }
+            // 真正的用户取消必须向上传播中止整个流程——否则取消被吞成"某个稿件失败"，
+            // 批量解析会在取消信号下继续空转（还可能触发连续失败/风控）。
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             // 过滤范围要覆盖所有"单个稿件"级别的故障：稿件失效（InvalidOperationException）、
             // 网络瞬断（HttpRequestException/IOException）、请求超时（TaskCanceledException，

--- a/BBDown.Core/Logger.cs
+++ b/BBDown.Core/Logger.cs
@@ -8,6 +8,11 @@ public static class Logger
     // 会互相插入颜色区间，导致日志颜色错乱、行内容交错。单条日志的写入需整体加锁。
     private static readonly object _consoleLock = new();
 
+    // 文件追加独立串行化：File.AppendAllText 对同进程多线程并发调用虽不抛错，
+    // 但行间可能交错/截断，且与 Console 写入的先后顺序不保证。serve 并发下载时
+    // 统一经本锁写文件，保证"一行日志 = 一次完整写盘"。
+    private static readonly object _fileLock = new();
+
     private static void WriteLine(string line)
     {
         Console.WriteLine(line);
@@ -20,7 +25,10 @@ public static class Logger
         if (string.IsNullOrEmpty(path)) return;
         try
         {
-            File.AppendAllText(path, line + Environment.NewLine);
+            lock (_fileLock)
+            {
+                File.AppendAllText(path, line + Environment.NewLine);
+            }
         }
         catch { /* silently ignore file write failures */ }
     }

--- a/BBDown.Core/Parser.cs
+++ b/BBDown.Core/Parser.cs
@@ -26,7 +26,7 @@ public static partial class Parser
         bool bangumi = cheese || aidOri.StartsWith("ep:");
         Logger.LogDebug("bangumi={0},cheese={1}", bangumi, cheese);
 
-        if (appApi) return await AppHelper.DoReqAsync(aid, cid, epId, qn, bangumi, encoding, Config.Current.Token);
+        if (appApi) return await AppHelper.DoReqAsync(aid, cid, epId, qn, bangumi, encoding, Config.Current.Token, token);
 
         string prefix = tvApi ? bangumi ? $"{Config.Current.TvHost}/pgc/player/api/playurltv" : $"{Config.Current.TvHost}/x/tv/playurl"
             : bangumi ? $"{Config.Current.Host}/pgc/player/web/v2/playurl" : "api.bilibili.com/x/player/wbi/playurl";
@@ -110,7 +110,15 @@ public static partial class Parser
         //调用解析
         parsedResult.WebJsonString = await GetPlayJsonAsync(encoding, aidOri, aid, cid, epId, tvApi, intlApi, appApi, wantDrm, qn, token);
 
-        Logger.LogDebug(parsedResult.WebJsonString);
+        // 调试日志不记录完整播放 JSON：其中包含带签名的媒体地址（deadline/sign 参数），
+        // 全文落盘会把可用的临时签名 URL 写进日志文件。只记录长度 + 前 1KB 摘要，
+        // 排查问题足够，避免签名媒体地址泄漏到日志。
+        if (Config.Current.DebugLog)
+        {
+            Logger.LogDebug("PlayJson {0} chars: {1}",
+                parsedResult.WebJsonString.Length,
+                parsedResult.WebJsonString.Length > 1024 ? parsedResult.WebJsonString[..1024] + "…" : parsedResult.WebJsonString);
+        }
 
         //intl接口需要两次请求(code=0和code=1)
         if (intlApi)
@@ -196,6 +204,11 @@ public static partial class Parser
             respJson.Dispose();
             throw;
         }
+        // 外层 try/finally：覆盖 356 行 DRM 提取 throw、250/455 行 GetPlayJsonAsync
+        // await 抛错等所有中途异常路径——respJson 已 parse 但未走到方法末尾 dispose 时，
+        // 由 finally 统一释放（JsonDocument.Dispose 幂等，与 262/456 的显式释放不冲突）。
+        try
+        {
         // 根据API版本自动定位数据节点
         JsonElement root;
         if (data.TryGetProperty("result", out var resultElem) && resultElem.ValueKind == JsonValueKind.Object)
@@ -534,6 +547,11 @@ public static partial class Parser
 
         respJson.Dispose();
         return parsedResult;
+        }
+        finally
+        {
+            respJson.Dispose();
+        }
     }
 
     internal static void ThrowIfPlayLimited(JsonElement root)

--- a/BBDown.Core/Util/BuvidProvider.cs
+++ b/BBDown.Core/Util/BuvidProvider.cs
@@ -10,21 +10,20 @@ public static class BuvidProvider
     private static readonly SemaphoreSlim _gate = new(1, 1);
 
     /// <summary>
-    /// 确保 Cookie 中带有 buvid3。
-    /// 部分接口（如 UP 主投稿列表 <c>x/space/wbi/arc/search</c>）会对缺少 buvid3 的请求
-    /// 直接返回 412，即便 wbi 签名完全正确——未登录时 Cookie 为空，必然触发。
-    /// 已存在 buvid3 时不做改动，避免覆盖用户自带的 Cookie。
-    /// 取不到也不视为错误：绝大多数接口并不要求 buvid3。
+    /// 确保 Cookie 中带有 buvid3。返回注入后的完整 Cookie；无需注入/获取失败返回 null。
+    /// 注意：不在此处写 Config——AsyncLocal 写入发生在子方法内不会回流父调用方
+    /// （父流程的 ExecutionContext 快照在 await 前已捕获）。由调用方拿到返回值后
+    /// 在自身流程内显式应用（覆盖其自身请求的凭据读取）。
     /// </summary>
-    public static async Task EnsureAsync(CancellationToken token = default)
+    public static async Task<string?> EnsureAsync(CancellationToken token = default)
     {
-        if (HasBuvid3(Config.Current.Cookie)) return;
+        if (HasBuvid3(Config.Current.Cookie)) return null;
 
         await _gate.WaitAsync(token);
         try
         {
             // 并发进入时，先到者可能已经补好了
-            if (HasBuvid3(Config.Current.Cookie)) return;
+            if (HasBuvid3(Config.Current.Cookie)) return null;
 
             var source = await HTTPUtil.GetWebSourceAsync("https://api.bilibili.com/x/frontend/finger/spi", token: token);
             using var doc = JsonDocument.Parse(source);
@@ -32,20 +31,20 @@ public static class BuvidProvider
             if (string.IsNullOrEmpty(buvid3))
             {
                 Logger.LogDebug("spi 接口未返回 b_3，跳过 buvid3 注入");
-                return;
+                return null;
             }
 
             var cookie = Config.Current.Cookie;
-            // 只更新当前异步流的 Cookie：serve 并发任务下写全局会被后写者覆盖，
-            // 使其它任务读到被污染后的凭据（跨账号串号）。flow-scoped 改动只对本任务生效。
-            Config.COOKIE_FLOW = string.IsNullOrEmpty(cookie)
+            string updated = string.IsNullOrEmpty(cookie)
                 ? $"buvid3={buvid3}"
                 : $"{cookie.TrimEnd(';')};buvid3={buvid3}";
             Logger.LogDebug("已获取 buvid3: {0}", buvid3);
+            return updated;
         }
         catch (Exception ex) when (ex is HttpRequestException or JsonException or KeyNotFoundException or InvalidOperationException)
         {
             Logger.LogDebug("获取 buvid3 失败: {0}", ex.Message);
+            return null;
         }
         finally
         {

--- a/BBDown.Core/Util/HTTPUtil.cs
+++ b/BBDown.Core/Util/HTTPUtil.cs
@@ -13,12 +13,41 @@ public static class HTTPUtil
             AllowAutoRedirect = true,
             AutomaticDecompression = DecompressionMethods.All,
             PooledConnectionLifetime = TimeSpan.FromMinutes(5),
+            SslOptions = CreateSslOptions(),
         };
-        // 注意：不能在客户端创建时把 SkipSslCheck 固化成闭包。CLI 的更新检查
-        // （CheckUpdateAsync）会先于 SetUpWork 的 Config.Apply 触发本 Lazy 初始化，
-        // 固化会导致 --insecure 永不生效；serve 模式下每个任务流的取值还可能不同。
-        // 因此在每次证书校验时读取当前流（AsyncLocal）的配置。
-        handler.SslOptions = new System.Net.Security.SslClientAuthenticationOptions
+        return new HttpClient(handler) { Timeout = TimeSpan.FromMinutes(2) };
+    }
+
+    // 并发下载与 serve 模式会从多个线程首次访问，Lazy 保证只创建一个 HttpClient，
+    // 否则多余实例各自持有一份 SocketsHttpHandler 连接池，造成 socket 泄漏。
+    private static readonly Lazy<HttpClient> _appHttpClient =
+        new(CreateAppHttpClient, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    public static HttpClient AppHttpClient => _appHttpClient.Value;
+
+    /// <summary>
+    /// 禁自动跳转的共享客户端：供逐跳校验重定向（GetWebLocationCheckedAsync /
+    /// GetWebSourceAnonymousCheckedAsync）复用。手动逐跳跟随需要 AllowAutoRedirect=false，
+    /// 每次跳转新建 HttpClient 会重复建连接池；共享实例避免 socket 泄漏与握手开销。
+    /// 与 AppHttpClient 相同的 SSL 校验策略（读取当前流配置的 SkipSslCheck）。
+    /// </summary>
+    private static readonly Lazy<HttpClient> _noRedirectClient = new(() =>
+    {
+        var handler = new SocketsHttpHandler
+        {
+            AllowAutoRedirect = false,
+            AutomaticDecompression = DecompressionMethods.All,
+            PooledConnectionLifetime = TimeSpan.FromMinutes(5),
+            SslOptions = CreateSslOptions(),
+        };
+        return new HttpClient(handler) { Timeout = TimeSpan.FromMinutes(1) };
+    }, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    private static System.Net.Security.SslClientAuthenticationOptions CreateSslOptions()
+    {
+        if (Config.Current.SkipSslCheck)
+            Logger.LogDebug("SSL 证书验证已禁用");
+        return new System.Net.Security.SslClientAuthenticationOptions
         {
             RemoteCertificateValidationCallback = (sender, cert, chain, errors) =>
             {
@@ -31,17 +60,7 @@ public static class HTTPUtil
                 return errors == System.Net.Security.SslPolicyErrors.None;
             },
         };
-        if (Config.Current.SkipSslCheck)
-            Logger.LogDebug("SSL 证书验证已禁用");
-        return new HttpClient(handler) { Timeout = TimeSpan.FromMinutes(2) };
     }
-
-    // 并发下载与 serve 模式会从多个线程首次访问，Lazy 保证只创建一个 HttpClient，
-    // 否则多余实例各自持有一份 SocketsHttpHandler 连接池，造成 socket 泄漏。
-    private static readonly Lazy<HttpClient> _appHttpClient =
-        new(CreateAppHttpClient, LazyThreadSafetyMode.ExecutionAndPublication);
-
-    public static HttpClient AppHttpClient => _appHttpClient.Value;
 
     private static readonly string[] platforms = { "Windows NT 10.0; Win64", "Macintosh; Intel Mac OS X 10_15", "X11; Linux x86_64" };
 
@@ -80,13 +99,6 @@ public static class HTTPUtil
     public static async Task<string> GetWebSourceAnonymousCheckedAsync(string url,
         Func<Uri, bool> validateNextHop, string? userAgent = null, int maxHops = 10, CancellationToken token = default)
     {
-        var handler = new SocketsHttpHandler
-        {
-            AllowAutoRedirect = false,
-            AutomaticDecompression = DecompressionMethods.All,
-            PooledConnectionLifetime = TimeSpan.FromMinutes(1),
-        };
-        using var client = new HttpClient(handler) { Timeout = TimeSpan.FromMinutes(1) };
         string current = url;
         for (int hop = 0; hop < maxHops; hop++)
         {
@@ -96,7 +108,7 @@ public static class HTTPUtil
             webRequest.Headers.CacheControl = CacheControlHeaderValue.Parse("no-cache");
             webRequest.Headers.Connection.Clear();
 
-            using var response = await client.SendAsync(webRequest, HttpCompletionOption.ResponseHeadersRead, token);
+            using var response = await _noRedirectClient.Value.SendAsync(webRequest, HttpCompletionOption.ResponseHeadersRead, token);
             if ((int)response.StatusCode is >= 300 and < 400)
             {
                 var location = response.Headers.Location;
@@ -185,13 +197,7 @@ public static class HTTPUtil
     public static async Task<string> GetWebLocationCheckedAsync(string url,
         Func<Uri, bool> validateNextHop, int maxHops = 10, CancellationToken token = default)
     {
-        var handler = new SocketsHttpHandler
-        {
-            AllowAutoRedirect = false,
-            AutomaticDecompression = DecompressionMethods.All,
-            PooledConnectionLifetime = TimeSpan.FromMinutes(1),
-        };
-        using var client = new HttpClient(handler) { Timeout = TimeSpan.FromMinutes(1) };
+        // 复用共享的禁自动跳转客户端：每次跳转新建 HttpClient 会重复建连接池
         string current = url;
         for (int hop = 0; hop < maxHops; hop++)
         {
@@ -205,7 +211,7 @@ public static class HTTPUtil
                 webRequest.Headers.CacheControl = CacheControlHeaderValue.Parse("no-cache");
                 webRequest.Headers.Connection.Clear();
 
-                using var response = await client.SendAsync(webRequest, HttpCompletionOption.ResponseHeadersRead, token);
+                using var response = await _noRedirectClient.Value.SendAsync(webRequest, HttpCompletionOption.ResponseHeadersRead, token);
                 if ((int)response.StatusCode is >= 300 and < 400)
                 {
                     var location = response.Headers.Location;
@@ -247,7 +253,7 @@ public static class HTTPUtil
                     getRequest.Headers.CacheControl = CacheControlHeaderValue.Parse("no-cache");
                     getRequest.Headers.Connection.Clear();
 
-                    using var getResponse = await client.SendAsync(getRequest, HttpCompletionOption.ResponseHeadersRead, token);
+                    using var getResponse = await _noRedirectClient.Value.SendAsync(getRequest, HttpCompletionOption.ResponseHeadersRead, token);
                     if ((int)getResponse.StatusCode is >= 300 and < 400)
                     {
                         var location = getResponse.Headers.Location;

--- a/BBDown.Core/Util/PathUtil.cs
+++ b/BBDown.Core/Util/PathUtil.cs
@@ -26,7 +26,11 @@ public static class PathUtil
             title = title.Replace("/", re);
             title = title.Replace("\\", re);
         }
-        if (ReservedNames.Contains(title))
+        // Windows 保留名规则：CON/PRN/AUX/NUL/COM1..9/LPT1..9 后跟任意扩展名仍然保留
+        // （CON.txt、CON.foo 在 Windows 上同样无法创建）。因此按基名匹配，
+        // 而不是只匹配完整名称——否则 "CON.txt" 会漏过校验而在 Windows 上报错。
+        var nameWithoutExt = Path.GetFileNameWithoutExtension(title);
+        if (ReservedNames.Contains(title) || ReservedNames.Contains(nameWithoutExt))
             title = "_" + title;
         return title;
     }

--- a/BBDown.Tests/ConfigPropagationTests.cs
+++ b/BBDown.Tests/ConfigPropagationTests.cs
@@ -1,0 +1,74 @@
+using System.Threading;
+using System.Threading.Tasks;
+using BBDown;
+using BBDown.Core;
+using BBDown.Core.Util;
+using Xunit;
+
+namespace BBDown.Tests;
+
+/// <summary>
+/// 验证 AsyncLocal 配置传播修复：子异步方法内写 Config 不回流父调用方，
+/// 必须由子方法显式返回新值、父流程应用后才生效。
+/// </summary>
+public class ConfigPropagationTests
+{
+    [Fact]
+    public async Task SubMethod_SetConfig_DoesNotFlowBackToParent()
+    {
+        // 记录父流程初始值
+        Config.ApplyToCurrentAsyncFlow(Config.Current with { Wbi = "parent-wbi" });
+
+        // 子方法内设置（模拟 TryUpdateWbiKey 的旧行为）
+        async Task Child()
+        {
+            Config.ApplyToCurrentAsyncFlow(Config.Current with { Wbi = "child-wbi" });
+            await Task.Yield();
+        }
+        await Child();
+
+        // 父流程仍读旧值——这正是报告指出的缺陷根因
+        Assert.Equal("parent-wbi", Config.Current.Wbi);
+    }
+
+    [Fact]
+    public async Task Parent_AppliesReturnedValue_SeesNewConfig()
+    {
+        Config.ApplyToCurrentAsyncFlow(Config.Current with { Wbi = "parent-wbi" });
+
+        // 子方法返回新值（修复后的模式），父流程显式应用
+        async Task<string?> Child()
+        {
+            await Task.Yield();
+            return "child-wbi";
+        }
+        string? newWbi = await Child();
+        if (newWbi is not null) Config.ApplyToCurrentAsyncFlow(Config.Current with { Wbi = newWbi });
+
+        Assert.Equal("child-wbi", Config.Current.Wbi);
+    }
+
+    [Fact]
+    public void ExtractWbiKey_IsInternalAndPure()
+    {
+        // 验证 CheckLoginWithDetails 的提取逻辑已从"写 Config"改为"返回新值"：
+        // 通过 reflection 检查方法签名应返回 string?（newWbi 元组第三元）。
+        var method = typeof(BBDownUtil).GetMethod("CheckLoginWithDetails");
+        Assert.NotNull(method);
+        var ret = method!.ReturnType;
+        Assert.True(ret.IsGenericType && ret.GetGenericTypeDefinition() == typeof(Task<>));
+        var tuple = ret.GetGenericArguments()[0];
+        Assert.True(tuple.IsGenericType && tuple.GetGenericTypeDefinition() == typeof(ValueTuple<,,>),
+            "CheckLoginWithDetails 应返回 (isLoggedIn, cookieExpired, newWbi) 三元组");
+    }
+
+    [Fact]
+    public void EnsureAsync_ReturnsUpdatedCookie_InsteadOfWritingConfig()
+    {
+        // EnsureAsync 签名应从 Task 改为 Task<string?>（返回新 Cookie 由调用方应用）
+        var method = typeof(BuvidProvider).GetMethod("EnsureAsync");
+        Assert.NotNull(method);
+        var ret = method!.ReturnType;
+        Assert.Equal(typeof(Task<string?>), ret);
+    }
+}

--- a/BBDown.Tests/DownloadPipelineTests.cs
+++ b/BBDown.Tests/DownloadPipelineTests.cs
@@ -137,6 +137,50 @@ public class DownloadPipelineTests
         }
     }
 
+    [Fact]
+    public async Task MultiThreadDownloadAndMerge_OversizedStaleClip_IsTruncatedNotMerged()
+    {
+        // 回归：旧分片若比目标分片更长（上次中断留下的超长尾部），必须在完成判定前
+        // SetLength 截断，否则合并带入多余尾部、长度校验失败、重试仍见同一超长分片
+        // → 永久失败循环。这里预置一个超长 .vclip，验证最终产物长度仍等于服务器总长。
+        using var server = new LocalByteServer(256 * 1024);
+        var dir = Path.Combine(Path.GetTempPath(), "bbdown-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var target = Path.Combine(dir, "video.mp4");
+        try
+        {
+            // 预置超长分片：stem=video、扩展名 .mp4 → 分片名 00000_video.vclip
+            var clipPath = Path.Combine(dir, "00000_video.vclip");
+            var oversized = new byte[512 * 1024]; // 目标 256KB，旧分片 512KB
+            new Random(1).NextBytes(oversized);
+            await File.WriteAllBytesAsync(clipPath, oversized);
+
+            var config = new BBDownDownloadUtil.DownloadConfig { MultiThread = true };
+            var original = Config.Current.ThreadSegmentSizeMb;
+            try
+            {
+                Config.Apply(Config.Current with { ThreadSegmentSizeMb = 1 }); // 1MB 分片 → 1 个分片
+                await BBDownDownloadUtil.MultiThreadDownloadAndMergeAsync(
+                    $"http://127.0.0.1:{server.Port}/file", target, config, CancellationToken.None);
+            }
+            finally
+            {
+                Config.Apply(Config.Current with { ThreadSegmentSizeMb = original });
+            }
+
+            // 产物长度等于服务器总长：超长旧分片尾部未被带入
+            Assert.True(File.Exists(target), "目标文件应已合并生成");
+            Assert.Equal(256 * 1024, new FileInfo(target).Length);
+            // 分片已清理
+            Assert.Empty(Directory.GetFiles(dir, "*.vclip"));
+            Assert.Equal(0, BBDownDownloadUtil.ActivePathLockCount);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
     /// <summary>本地 HTTP 服务，返回固定长度的字节流（用于多线程下载测试）。</summary>
     private sealed class LocalByteServer : IDisposable
     {

--- a/BBDown.Tests/ServeApiHttpTests.cs
+++ b/BBDown.Tests/ServeApiHttpTests.cs
@@ -99,6 +99,17 @@ public class ServeApiHttpTests
     }
 
     [Fact]
+    public async Task AddTask_OversizedBody_Returns400()
+    {
+        using var server = new RunningServer();
+        // 请求体超过 64KB 上限 → 绑定层返回 400，拒绝解析超大负载
+        var oversized = new { Url = "zz-not-a-real-url", Padding = new string('x', 128 * 1024) };
+        using var content = JsonContent.Create(oversized);
+        using var resp = await server.Client.PostAsync("/add-task", content);
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
     public async Task AddTask_UnresolvableUrl_Returns202AndProducesFailedTask()
     {
         using var server = new RunningServer();

--- a/BBDown/Application/Decrypt.cs
+++ b/BBDown/Application/Decrypt.cs
@@ -64,14 +64,17 @@ internal partial class Program
                 Logger.LogWarn($"自动密钥提取异常: {ex.Message}");
             }
 
-            if (string.IsNullOrEmpty(parsed.KeyHex))
+            // 取钥必须同时得到 Key 与 Kid：mp4decrypt 的 key-file 行格式是 "kid:key"，
+            // Kid 为空会生成 ":key" 无效行导致解密失败或静默产出错误输出。
+            // 仅检查 KeyHex 会放过 KidHex 为空的半成品（手动 --key 未配 --kid）。
+            if (string.IsNullOrEmpty(parsed.KeyHex) || string.IsNullOrEmpty(parsed.KidHex))
             {
                 // 用户显式请求了 DRM 解密（--decrypt-drm / --key / --kid）但取钥失败：
                 // 若只是打印警告并 return，任务会继续把"仍是加密的流"当成功产物混流/交付，
                 // 用户拿到加密文件却被告知下载成功。这里抛异常让调用方把任务标记为失败，
                 // 而不是静默交付加密产物。
                 throw new InvalidOperationException(
-                    "DRM 解密密钥获取失败，无法解密。请确保 device.wvd 位于程序目录，或使用 --key --kid 手动提供密钥。");
+                    "DRM 解密密钥获取失败（Key 或 Kid 缺失），无法解密。请确保 device.wvd 位于程序目录，或使用 --key --kid 同时提供密钥。");
             }
         }
 
@@ -158,6 +161,12 @@ internal partial class Program
                 var err = await stderrTask;
                 try { if (File.Exists(output)) File.Delete(output); } catch (IOException) { }
                 throw new InvalidOperationException($"mp4decrypt 解密失败 (code={proc.ExitCode}): {err}");
+            }
+            // 进程退出 0 但未产出有效文件：静默忽略会让调用方保留原加密文件、
+            // 任务却继续"解密成功"。这里把缺失输出当作失败抛出。
+            if (!File.Exists(output) || new FileInfo(output).Length == 0)
+            {
+                throw new InvalidOperationException("mp4decrypt 退出码为 0 但未产出有效的解密文件");
             }
         }
         finally

--- a/BBDown/Application/Download.cs
+++ b/BBDown/Application/Download.cs
@@ -243,6 +243,10 @@ internal partial class Program
         // 全部分P（-p all）时，<pageNumberWithZero> 应产生相同宽度的文件名，
         // 否则同一视频因筛选方式不同会得到不同路径（P01 vs P1）。
         var pagesCount = vInfo.PagesInfo.Count;
+        // 产物成功判定：是否实际生成了至少一个请求的输出产物。
+        // SubOnly/VideoOnly/AudioOnly/DanmakuOnly 等提前返回模式若零产物，
+        // 必须返回 false 而非假成功（否则 CLI/Serve 报成功、SavePaths 为空）。
+        bool anyProductProduced = false;
         List<Subtitle> subtitleInfo = [];
         string title = vInfo.Title;
         string pic = vInfo.Pic;
@@ -315,6 +319,7 @@ internal partial class Program
                                 // 记录最终产物：SubOnly 提前返回不经过下方统一 AddSavePath，
                                 // 若这里不记录，serve API 的成功响应里产物列表会缺字幕文件。
                                 relatedTask?.AddSavePath(_outSubPath);
+                                anyProductProduced = true;
                             }
                         }
                     }
@@ -322,6 +327,13 @@ internal partial class Program
                     if (myOption.SubOnly)
                     {
                         if (Directory.Exists(p.aid) && Directory.GetFiles(p.aid).Length == 0) Directory.Delete(p.aid, true);
+                        // SubOnly 但没有任何字幕生成（视频无字幕/全部跳过）→ 零产物成功。
+                        // 必须返回 false，避免 CLI 报成功、serve 标记 Succeeded、SavePaths 为空。
+                        if (!anyProductProduced)
+                        {
+                            Logger.LogWarn("SubOnly 模式未生成任何字幕文件");
+                            return false;
+                        }
                         return true;
                     }
                 }
@@ -395,12 +407,14 @@ internal partial class Program
                     if (parsedResult.VideoTracks.Count == 0)
                     {
                         Logger.LogWarn("没有找到符合要求的视频流");
-                        if (myOption.VideoOnly) return true;
+                        // VideoOnly 但没有任何视频流 → 零产物：返回 false 而非假成功
+                        if (myOption.VideoOnly) return false;
                     }
                     if (parsedResult.AudioTracks.Count == 0)
                     {
                         Logger.LogWarn("没有找到符合要求的音频流");
-                        if (myOption.AudioOnly) return true;
+                        // AudioOnly 但没有任何音频流 → 零产物：返回 false 而非假成功
+                        if (myOption.AudioOnly) return false;
                     }
 
                     if (myOption.AudioOnly)
@@ -495,13 +509,27 @@ internal partial class Program
                         {
                             // 记录最终产物：DanmakuOnly 提前返回不经过下方统一 AddSavePath，
                             // 若这里不记录，serve API 的成功响应里产物列表会缺弹幕文件。
+                            bool danmakuProduced = false;
                             if (downloadDanmakuFormats.Contains(BBDownDanmakuFormat.Xml) && File.Exists(danmakuXmlPath))
+                            {
                                 relatedTask?.AddSavePath(danmakuXmlPath);
+                                danmakuProduced = true;
+                            }
                             if (downloadDanmakuFormats.Contains(BBDownDanmakuFormat.Ass) && File.Exists(danmakuAssPath))
+                            {
                                 relatedTask?.AddSavePath(danmakuAssPath);
+                                danmakuProduced = true;
+                            }
                             if (Directory.Exists(p.aid))
                             {
                                 Directory.Delete(p.aid);
+                            }
+                            // DanmakuOnly 但没有任何有效弹幕文件（解析失败/为空/过滤后为空被删除）
+                            // → 零产物：返回 false 而非假成功
+                            if (!danmakuProduced)
+                            {
+                                Logger.LogWarn("DanmakuOnly 模式未生成任何弹幕文件");
+                                return false;
                             }
                             return true;
                         }
@@ -512,6 +540,14 @@ internal partial class Program
                         // 仅下载封面：封面保存成功后必须立即 return，否则会继续执行下方
                         // 轨道解析、视频/音频下载与混流——用户只要封面却白白下载完整视频。
                         var coverUrl = pic == "" ? p.cover! : pic;
+                        // coverUrl 为空时 DownloadFileAsync 直接返回（不生成文件）：
+                        // 此时若仍 AddSavePath 并 return true，SavePaths 指向不存在的文件。
+                        // 无封面资源时明确失败，避免零产物成功。
+                        if (string.IsNullOrEmpty(coverUrl))
+                        {
+                            Logger.LogWarn("CoverOnly 模式无封面资源可下载");
+                            return false;
+                        }
                         var newCoverPath = Path.ChangeExtension(savePath, Path.GetExtension(coverUrl));
                         await BBDownDownloadUtil.DownloadFileAsync(coverUrl, newCoverPath, downloadConfig, cancellationToken);
                         if (Directory.Exists(p.aid) && Directory.GetFiles(p.aid).Length == 0) Directory.Delete(p.aid, true);
@@ -603,6 +639,12 @@ internal partial class Program
                             {
                                 Logger.LogWarn($"评论数量达到抓取上限（{commentPage.Items.Count} 条），可能还有更多评论未导出");
                             }
+                        }
+                        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                        {
+                            // 用户取消：必须向上传播，不能当"评论失败已跳过"吞掉——
+                            // 否则取消信号丢失，后续 SkipMux 等分支仍返回成功。
+                            throw;
                         }
                         catch (Exception ex) when (ex is HttpRequestException or JsonException or InvalidOperationException
                                                     or IOException or TaskCanceledException or KeyNotFoundException or FormatException)

--- a/BBDown/Application/PathHelper.cs
+++ b/BBDown/Application/PathHelper.cs
@@ -57,7 +57,9 @@ internal partial class Program
             };
             result = result.Replace(m.Value, v);
         }
-        if (!result.EndsWith(".mp4")) { result += ".mp4"; }
+        // 大小写不敏感判断：用户模板可能产出 ".MP4"/".Mp4"（例如占位符替换自大写扩展名），
+        // 大小写敏感会让 ".MP4" 再被追加一次 ".mp4" 变成 ".MP4.mp4"。
+        if (!result.EndsWith(".mp4", StringComparison.OrdinalIgnoreCase)) { result += ".mp4"; }
         return result;
     }
 

--- a/BBDown/Application/Workflow.cs
+++ b/BBDown/Application/Workflow.cs
@@ -86,7 +86,10 @@ internal partial class Program
         if (myOption is { UseIntlApi: false, UseTvApi: false } && Config.Current.Area == "")
         {
             Logger.Log("检测账号登录...");
-            var (isLoggedIn, cookieExpired) = await BBDownUtil.CheckLoginWithDetails(Config.Current.Cookie, cancellationToken);
+            var (isLoggedIn, cookieExpired, newWbi) = await BBDownUtil.CheckLoginWithDetails(Config.Current.Cookie, cancellationToken);
+            // 子方法提取的 wbi 不会自动回流（AsyncLocal 写入只影响子方法内部），
+            // 由父流程显式写入当前任务流的配置，后续请求的 w_rid 签名才能用上新密钥。
+            if (newWbi is not null) Core.Config.WBI_FLOW = newWbi;
             if (!isLoggedIn)
             {
                 if (cookieExpired)

--- a/BBDown/BBDown.csproj
+++ b/BBDown/BBDown.csproj
@@ -15,9 +15,24 @@
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <NoWarn>$(NoWarn);IL3050;IL3000;IL3001;IL3002;IL2067</NoWarn>
+    <NoWarn>$(NoWarn);IL3050;IL3000;IL3001;IL3002;IL2067;IL2104</NoWarn>
     <InternalsVisibleTo>BBDown.Tests</InternalsVisibleTo>
+
+    <!-- Release 发布/打包产物瘦身：
+         - DebugType none：AOT 发布不产出 89MB 的 PDB（主程序约 21MB），
+           Native AOT 的符号已由 Directory.Build.props 的 StripSymbols 处理。
+         - 仅对 Debug 保留可调试符号。 -->
+    <DebugType Condition="'$(Configuration)' == 'Release'">none</DebugType>
+    <DebugSymbols Condition="'$(Configuration)' == 'Release'">false</DebugSymbols>
+
+    <!-- Package README：NuGet 包应携带使用说明。 -->
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <!-- 包内 README（从仓库根引用，pack 时自动包含） -->
+    <None Include="..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="QRCoder" Version="1.8.0" />

--- a/BBDown/Commands/SubCommand.cs
+++ b/BBDown/Commands/SubCommand.cs
@@ -142,6 +142,7 @@ public class SubCheckCommand : Command<SubCheckSettings>
                 UseAppApi = settings.UseAppApi,
             });
 
+            int failedSubs = 0;
             foreach (var sub in subs)
             {
                 Logger.Log($"检查订阅: {sub.Name} ({sub.Target})");
@@ -174,8 +175,16 @@ public class SubCheckCommand : Command<SubCheckSettings>
                 catch (Exception ex) when (ex is HttpRequestException or JsonException or KeyNotFoundException
                                             or InvalidOperationException or IOException or ArgumentException)
                 {
+                    // 单个订阅失败不中止其余订阅，但必须计入失败数：
+                    // 全部失败仍返回 0 会让脚本/CI 无法区分"全部成功"与"全部失败"
+                    failedSubs++;
                     Logger.LogWarn($"  订阅检查失败: {ex.Message}");
                 }
+            }
+            if (failedSubs > 0)
+            {
+                Logger.LogWarn($"订阅检查完成，{failedSubs} 个订阅失败");
+                return 1;
             }
             return 0;
         }).GetAwaiter().GetResult();

--- a/BBDown/Infrastructure/BBDownApiServer.cs
+++ b/BBDown/Infrastructure/BBDownApiServer.cs
@@ -1114,18 +1114,42 @@ record struct MyOptionBindingResult<T>(T? Result, Exception? Exception)
             {
                 return new(default, new InvalidOperationException($"Cannot find TypeInfo for type {typeof(T)}"));
             }
-            var json = await new StreamReader(httpContext.Request.Body).ReadToEndAsync(httpContext.RequestAborted);
+            // 请求体大小限制：/add-task 的合法负载很小（Url + 少量选项）。
+            // 不设上限会让攻击者用超大 body 耗尽内存/带宽（长驻 serve 进程）。
+            // Content-Length 超限直接 413；无 Content-Length（chunked）时读满上限即止。
+            if (httpContext.Request.ContentLength is > MaxRequestBodyBytes)
+            {
+                return new(default, new InvalidOperationException("请求体过大"));
+            }
+            using var ms = new MemoryStream();
+            var buffer = new byte[4096];
+            long total = 0;
+            while (true)
+            {
+                int read = await httpContext.Request.Body.ReadAsync(buffer.AsMemory(0, buffer.Length), httpContext.RequestAborted);
+                if (read == 0) break;
+                total += read;
+                if (total > MaxRequestBodyBytes)
+                {
+                    return new(default, new InvalidOperationException("请求体过大"));
+                }
+                ms.Write(buffer, 0, read);
+            }
+            var json = System.Text.Encoding.UTF8.GetString(ms.ToArray());
             var item = JsonSerializer.Deserialize<T>(json, typedInfo);
 
             if (item is null) return new(default, new NoNullAllowedException());
 
             return new((T)item, null);
         }
-        catch (Exception ex) when (ex is JsonException or NotSupportedException)
+        catch (Exception ex) when (ex is JsonException or NotSupportedException or InvalidOperationException)
         {
             return new(default, ex);
         }
     }
+
+    /// <summary>/add-task 请求体大小上限：合法负载远小于此值，超限即拒。</summary>
+    private const long MaxRequestBodyBytes = 64 * 1024;
 }
 
 [JsonSerializable(typeof(ProblemDetails))]

--- a/BBDown/Infrastructure/BBDownDownloadUtil.cs
+++ b/BBDown/Infrastructure/BBDownDownloadUtil.cs
@@ -26,19 +26,28 @@ internal static class BBDownDownloadUtil
     private static async Task RangeDownloadToTmpAsync(int id, string url, string tmpName, long fromPosition, long? toPosition, Action<int, long, long> onProgress, bool failOnRangeNotSupported = false, CancellationToken token = default)
     {
         using var fileStream = new FileStream(tmpName, FileMode.OpenOrCreate);
-        // 分片起点：若旧分片已超出目标分片范围（上次中断后内容异常变大），Seek 到 End
-        // 会让 Range 起点越过目标分片末尾，持续返回 416。这里把起点钳制在分片范围内，
-        // 超出的旧尾部在写回时会被覆盖/截断。
         long clipLength = toPosition is > 0 ? toPosition.Value - fromPosition + 1 : long.MaxValue;
-        long startPos = Math.Min(fileStream.Length, clipLength);
-        fileStream.Seek(startPos, SeekOrigin.Begin);
-        if (toPosition > 0 && startPos == clipLength)
+
+        // 超长旧分片：上次中断可能留下超出目标分片范围的尾部（内容异常变大）。
+        // 必须先把文件截断到目标长度再判完成——否则合并会带入多余尾部、
+        // 长度校验失败，且下次重试仍看到同一个超长分片，形成永久失败循环。
+        if (fileStream.Length > clipLength)
+        {
+            fileStream.SetLength(clipLength);
+            fileStream.Seek(0, SeekOrigin.End);
+        }
+        else
+        {
+            fileStream.Seek(0, SeekOrigin.End);
+        }
+
+        if (toPosition > 0 && fileStream.Length == clipLength)
         {
             // 已下载完成 直接汇报进度并跳过下载
-            onProgress(id, startPos, startPos);
+            onProgress(id, clipLength, clipLength);
             return;
         }
-        var downloadedBytes = fromPosition + startPos;
+        var downloadedBytes = fromPosition + fileStream.Position;
 
         using var httpRequestMessage = new HttpRequestMessage();
         if (!url.Contains("platform=android_tv_yst") && !url.Contains("platform=android"))
@@ -265,10 +274,12 @@ internal static class BBDownDownloadUtil
             File.Move(tmpName, path, true);
             return;
         }
-        if (File.Exists(tmpName))
+        // 部分下载的临时文件直接续传：RangeDownloadToTmpAsync 会从现有长度处
+        // 发起 Range: bytes=N- 续传。此前这里删除不完整临时文件导致大文件/弱网
+        // 每次中断都从头重下，实际无法断点续传。
+        if (File.Exists(tmpName) && new FileInfo(tmpName).Length > 0)
         {
-            Logger.LogDebug("断点续传: 临时文件大小不匹配, 删除残留: {0}", tmpName);
-            File.Delete(tmpName);
+            Logger.LogDebug("断点续传: 从现有临时文件 {0} 字节处继续", new FileInfo(tmpName).Length);
         }
         int maxRetry = Config.Current.MaxRetryCount;
         while (retry < maxRetry)

--- a/BBDown/Infrastructure/LiveStreamUtil.cs
+++ b/BBDown/Infrastructure/LiveStreamUtil.cs
@@ -70,25 +70,31 @@ public static class LiveStreamUtil
     public static async Task<bool> DownloadToFileAsync(string roomId, string path, Action<long>? onProgress, CancellationToken token = default)
     {
         const int ReconnectLimit = 3;
-        var partPath = path + ".part";
-        // 清理上次录制留下的 .part（本次会话从头录制，会话内断流重连才续写）
-        if (File.Exists(partPath)) File.Delete(partPath);
+        // 每段独立文件：重连后的新 FLV 流含新的 FLV 头与重置时间戳，
+        // 直接追加到旧流末尾的原始字节拼接不保证可播放。记录在独立分段里，
+        // 录制结束后用 FFmpeg concat/remux 合成最终文件。
+        var segDir = path + ".segs";
+        if (Directory.Exists(segDir)) Directory.Delete(segDir, true);
+        Directory.CreateDirectory(segDir);
 
         long total = 0;
         int reconnect = 0;
+        int segIndex = 0;
+        var segmentFiles = new List<string>();
 
-        // 重连逻辑：重连计数递增，超限则保留 .part 并抛原异常，否则日志并等待 3 秒。
-        // HttpClient 超时（OCE 但 token 未取消）与一般瞬态故障两个 catch 共用。
+        // 重连逻辑：重连计数递增，超限则保留已录分段并抛原异常。
+        // 等待采用指数退避：零进展 EOF 也计入重试预算（见下），避免高速轮询。
         async Task ReconnectOrThrow(Exception ex)
         {
             reconnect++;
             if (reconnect > ReconnectLimit)
             {
-                Logger.LogWarn($"直播流中断且 {ReconnectLimit} 次重连失败，已录制内容保留在 {partPath}");
+                Logger.LogWarn($"直播流中断且 {ReconnectLimit} 次重连失败，已录制内容保留在 {segDir}");
                 ExceptionDispatchInfo.Capture(ex).Throw();
             }
-            Logger.LogWarn($"直播流中断（{ex.Message}），3 秒后重连（{reconnect}/{ReconnectLimit}）...");
-            await Task.Delay(3000, token);
+            int backoffMs = Math.Min(3000 * reconnect, 15000); // 3s → 6s → 9s → 15s
+            Logger.LogWarn($"直播流中断（{ex.Message}），{backoffMs / 1000} 秒后重连（{reconnect}/{ReconnectLimit}）...");
+            await Task.Delay(backoffMs, token);
         }
 
         try
@@ -99,20 +105,41 @@ public static class LiveStreamUtil
                 try
                 {
                     var (url, _, _, _) = await ResolveAsync(roomId, token);
-                    long before = total;
-                    total = await StreamToFileAsync(url, partPath, total, onProgress, token);
-                    // 流读到 EOF：可能是主播下播，也可能是 CDN 切换/连接到期产生的正常 EOF。
-                    // 若直接当作"主播下播"结束，CDN 切换时的截断录像会被当成成功产物。
-                    // 因此 EOF 后重新查询直播状态：仍在直播则重新解析地址续录，确认下播才结束。
-                    // 成功持续传输（本次会话收到新字节）后重置重连计数，避免偶发 EOF 消耗重连额度。
-                    if (total > before)
+                    var segPath = Path.Combine(segDir, $"seg-{segIndex++:000}.flv");
+                    long segBytes = await StreamToFileAsync(url, segPath, onProgress, token);
+                    // 本段收到任何字节都算有效传输，重置重连预算
+                    if (segBytes > 0)
                     {
+                        segmentFiles.Add(segPath);
+                        total += segBytes;
                         reconnect = 0;
                     }
+                    else
+                    {
+                        // 零字节 EOF：连接刚建立就结束。若直播仍进行，这是连接到期/CDN 切换，
+                        // 计入重试预算并退避，避免高速轮询（此前直接 continue 不延迟）。
+                        File.Delete(segPath);
+                        try
+                        {
+                            _ = await ResolveAsync(roomId, token);
+                            Logger.LogWarn("直播流连接立即结束但直播间仍在直播，正在退避后重连...");
+                            await ReconnectOrThrow(new IOException("直播流零字节 EOF"));
+                            continue;
+                        }
+                        catch (InvalidOperationException ex) when (ex.Message.Contains("当前未在直播"))
+                        {
+                            break; // 确认下播：结束录制
+                        }
+                        catch (Exception ex) when (ex is HttpRequestException or JsonException)
+                        {
+                            await ReconnectOrThrow(ex);
+                            continue;
+                        }
+                    }
+                    // EOF 后重新查询直播状态：仍在直播则重新解析地址续录，确认下播才结束。
                     try
                     {
                         _ = await ResolveAsync(roomId, token);
-                        // 仍在直播：EOF 是连接到期/CDN 切换，重解析地址续录
                         Logger.LogWarn("直播流连接结束但直播间仍在直播，正在重新解析流地址续录...");
                         continue;
                     }
@@ -122,13 +149,12 @@ public static class LiveStreamUtil
                     }
                     catch (Exception ex) when (ex is HttpRequestException or JsonException)
                     {
-                        // 重新查询直播状态失败：按瞬态故障重连
                         await ReconnectOrThrow(ex);
                     }
                 }
                 catch (OperationCanceledException) when (token.IsCancellationRequested)
                 {
-                    break; // 用户取消：保留已录制内容，退出后改名保存
+                    break; // 用户取消：保留已录分段，退出后合成保存
                 }
                 catch (OperationCanceledException ex)
                 {
@@ -137,7 +163,7 @@ public static class LiveStreamUtil
                 }
                 catch (Exception ex) when (ex is HttpRequestException or IOException or InvalidOperationException or JsonException)
                 {
-                    // 直播间下播（"当前未在直播"）是终结态而非可恢复故障：正常结束，走改名保存
+                    // 直播间下播（"当前未在直播"）是终结态而非可恢复故障：正常结束，走合成保存
                     if (ex is InvalidOperationException && ex.Message.Contains("当前未在直播"))
                         break;
                     await ReconnectOrThrow(ex);
@@ -146,35 +172,84 @@ public static class LiveStreamUtil
         }
         catch (OperationCanceledException) when (token.IsCancellationRequested)
         {
-            // 取消发生在重连等待 Task.Delay 或 while 顶部检查（try 外）：先走到循环后的改名保存再退出
+            // 取消发生在重连等待 Task.Delay 或 while 顶部检查（try 外）：先走到循环后的合成保存再退出
         }
 
         // 未收到任何字节：不生成空文件，返回 false 让调用方明确失败
         if (total == 0)
         {
-            if (File.Exists(partPath))
-            {
-                try { File.Delete(partPath); }
-                catch (IOException) { /* 清理失败不影响 */ }
-            }
+            try { if (Directory.Exists(segDir)) Directory.Delete(segDir, true); } catch (IOException) { }
             return false;
         }
 
-        if (File.Exists(partPath))
-            File.Move(partPath, path, true);
+        // 多段 → FFmpeg concat 合成最终文件；单段直接改名。
+        if (segmentFiles.Count == 1)
+        {
+            File.Move(segmentFiles[0], path, true);
+        }
+        else
+        {
+            if (!await ConcatSegmentsAsync(segmentFiles, path, token))
+            {
+                Logger.LogWarn($"直播分段合成失败，已录制分段保留在 {segDir}");
+                return false;
+            }
+        }
+        try { if (Directory.Exists(segDir)) Directory.Delete(segDir, true); } catch (IOException) { }
         return true;
     }
 
-    /// <summary>把一条直播流写到 <paramref name="partPath"/>（追加模式，续写重连前的已录内容），返回累计字节数。</summary>
-    private static async Task<long> StreamToFileAsync(string url, string partPath, long total, Action<long>? onProgress, CancellationToken token = default)
+    /// <summary>用 FFmpeg concat demuxer 把多个 FLV 分段合成一个文件。返回是否成功。</summary>
+    private static async Task<bool> ConcatSegmentsAsync(List<string> segmentFiles, string outPath, CancellationToken token)
+    {
+        // concat demuxer 需要逐行列出文件，FFmpeg 通过 ArgumentList 传参无法直接传换行
+        // 列表——这里写一个临时 concat 列表文件。路径含特殊字符时 concat 列表需要转义，
+        // 用 file '...' 单引号包裹（路径中单引号已由 SanitizeFileName 在文件生成阶段处理）。
+        var listPath = outPath + ".concat.txt";
+        try
+        {
+            await File.WriteAllLinesAsync(listPath, segmentFiles.Select(f => $"file '{f.Replace("'", "'\\''")}'"), token);
+            var args = new List<string>
+            {
+                "-loglevel", "warning", "-y",
+                "-f", "concat", "-safe", "0",
+                "-i", listPath,
+                "-c", "copy",
+                outPath,
+            };
+            // 复用统一外部进程执行器（与混流一致）：支持超时/取消时 Kill 整棵进程树
+            var spec = new ExternalProcessSpec
+            {
+                FileName = "ffmpeg",
+                Arguments = args,
+                TimeoutMs = Core.Config.Current.MuxerTimeoutMinutes * 60_000,
+                ToolDisplayName = "ffmpeg",
+            };
+            int code = await BBDownMuxer.ProcessRunner.RunAsync(spec, token);
+            return code == 0 && File.Exists(outPath) && new FileInfo(outPath).Length > 0;
+        }
+        catch (Exception ex) when (ex is IOException or InvalidOperationException)
+        {
+            Logger.LogDebug("直播分段合成失败: {0}", ex.Message);
+            return false;
+        }
+        finally
+        {
+            try { if (File.Exists(listPath)) File.Delete(listPath); } catch (IOException) { }
+        }
+    }
+
+    /// <summary>把一条直播流写到独立分段文件，返回本段写入的字节数。</summary>
+    private static async Task<long> StreamToFileAsync(string url, string segPath, Action<long>? onProgress, CancellationToken token = default)
     {
         using var req = new HttpRequestMessage(HttpMethod.Get, url);
         req.Headers.TryAddWithoutValidation("User-Agent", HTTPUtil.UserAgent);
         req.Headers.TryAddWithoutValidation("Referer", "https://live.bilibili.com/");
         using var response = (await HTTPUtil.AppHttpClient.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, token)).EnsureSuccessStatusCode();
         await using var stream = await response.Content.ReadAsStreamAsync(token);
-        await using var fs = new FileStream(partPath, FileMode.Append, FileAccess.Write, FileShare.None, 1 << 20, useAsync: true);
+        await using var fs = new FileStream(segPath, FileMode.Create, FileAccess.Write, FileShare.None, 1 << 20, useAsync: true);
         var buffer = ArrayPool<byte>.Shared.Rent(1 << 20);
+        long written = 0;
         try
         {
             while (true)
@@ -182,10 +257,10 @@ public static class LiveStreamUtil
                 var read = await stream.ReadAsync(buffer.AsMemory(0, buffer.Length), token);
                 if (read == 0) break; // 流结束（主播下播）
                 await fs.WriteAsync(buffer.AsMemory(0, read), token);
-                total += read;
-                onProgress?.Invoke(total);
+                written += read;
+                onProgress?.Invoke(written);
             }
-            return total;
+            return written;
         }
         finally
         {

--- a/BBDown/Infrastructure/SubscriptionStore.cs
+++ b/BBDown/Infrastructure/SubscriptionStore.cs
@@ -127,6 +127,9 @@ public static class SubscriptionStore
         }
         catch (Exception ex) when (ex is JsonException or IOException)
         {
+            // 历史文件损坏/不可读时不能静默当作"空历史"：会让已下载过的内容被
+            // 当作新增重新下载一遍（批量重复下载）。至少明确警告用户原因。
+            Logger.LogWarn($"读取订阅历史失败（{ex.Message}），已当作无历史处理，可能重新下载已下载内容: {HistoryFile}");
             return [];
         }
     }

--- a/BBDown/Utilities/BBDownUtil.cs
+++ b/BBDown/Utilities/BBDownUtil.cs
@@ -316,7 +316,7 @@ public static partial class BBDownUtil
         return tmp.ToString();
     }
 
-    public static async Task<(bool isLoggedIn, bool cookieExpired)> CheckLoginWithDetails(string cookie, CancellationToken token = default)
+    public static async Task<(bool isLoggedIn, bool cookieExpired, string? newWbi)> CheckLoginWithDetails(string cookie, CancellationToken token = default)
     {
         try
         {
@@ -329,7 +329,10 @@ public static partial class BBDownUtil
             // wbi 密钥必须在判断登录状态之前提取：nav 接口在未登录（code=-101）时
             // 依然会返回 wbi_img，而此前的提前 return 会跳过这一步，
             // 使未登录用户的 Config.WBI 恒为空串、w_rid 恒为无效签名。
-            TryUpdateWbiKey(json);
+            // 提取结果随元组返回，由父流程显式 Apply（AsyncLocal 写入不会回流父调用方）。
+            string? newWbi = ExtractWbiKey(json);
+            if (newWbi is not null)
+                Logger.LogDebug("wbi: {0}", newWbi);
 
             if (code == -101)
             {
@@ -341,23 +344,24 @@ public static partial class BBDownUtil
                 Logger.LogDebug(hasCookie
                     ? "Cookie 已过期或无效 (code=-101)"
                     : "尚未登录 (code=-101，本地无 Cookie)");
-                return (false, hasCookie);
+                return (false, hasCookie, newWbi);
             }
             var is_login = json.GetPropertySafe("data").GetPropertySafe("isLogin").GetBoolean();
-            return (is_login, false);
+            return (is_login, false, newWbi);
         }
         catch (Exception ex) when (ex is HttpRequestException or JsonException or KeyNotFoundException or InvalidOperationException)
         {
             Logger.LogDebug("检测登录状态失败: {0}", ex.Message);
-            return (false, false);
+            return (false, false, null);
         }
     }
 
     /// <summary>
-    /// 从 nav 响应中提取 wbi 混淆密钥。缺失时保持原值并记录，
-    /// 不因此让登录状态检测失败。
+    /// 从 nav 响应中提取 wbi 混淆密钥。返回新密钥；缺失/提取失败返回 null（保持原值）。
+    /// 注意：不在此处写入 Config——AsyncLocal 写入发生在子异步方法内不会回流父调用方
+    /// （父流程的 ExecutionContext 快照在 await 前已捕获）。由调用方拿到返回值后显式 Apply。
     /// </summary>
-    private static void TryUpdateWbiKey(JsonElement navRoot)
+    private static string? ExtractWbiKey(JsonElement navRoot)
     {
         try
         {
@@ -367,22 +371,23 @@ public static partial class BBDownUtil
             if (string.IsNullOrEmpty(imgUrl) || string.IsNullOrEmpty(subUrl))
             {
                 Logger.LogDebug("nav 响应中缺少 wbi_img，跳过 wbi 密钥更新");
-                return;
+                return null;
             }
-            // 只更新当前异步流的 wbi：serve 并发任务下，同时写全局会被最后执行的任务覆盖，
-            // 使其它任务读到串号后的密钥。这里用 flow-scoped setter，改动只对本任务流程生效。
-            Core.Config.WBI_FLOW = GetMixinKey(RSubString(imgUrl) + RSubString(subUrl));
-            Logger.LogDebug("wbi: {0}", Core.Config.WBI_FLOW);
+            return GetMixinKey(RSubString(imgUrl) + RSubString(subUrl));
         }
         catch (Exception ex) when (ex is KeyNotFoundException or InvalidOperationException)
         {
             Logger.LogDebug("提取 wbi 密钥失败: {0}", ex.Message);
+            return null;
         }
     }
 
     public static async Task<bool> CheckLogin(string cookie)
     {
-        var (isLoggedIn, _) = await CheckLoginWithDetails(cookie);
+        var (isLoggedIn, _, newWbi) = await CheckLoginWithDetails(cookie);
+        // 同步提取出的 wbi：CheckLogin 是 CLI 顶层单流程调用，子方法返回的新密钥
+        // 需由本调用方 Apply（AsyncLocal 写入不会自动回流）。
+        if (newWbi is not null) Core.Config.WBI_FLOW = newWbi;
         return isLoggedIn;
     }
     [GeneratedRegex("(^|&)?(\\w+)=([^&]+)(&|$)?", RegexOptions.Compiled)]

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ BBDown serve
 BBDown serve -l http://0.0.0.0:12450 --serve-token <token>
 ```
 
-> 安全提示：CLI 默认仅监听回环地址且无认证，仅建议在可信网络内使用。对外网开放时必须显式 `-l http://0.0.0.0:<port>` 并配合 `--serve-token`（所有 API 请求需携带 `X-Serve-Token` 请求头，否则 401）。`/add-task` 提交的 `host/epHost/tvHost` 仅接受 B 站官方域名、执行路径/代理/工作目录字段一律忽略。API 服务器不支持 HTTPS，如有需要请使用 nginx 等反向代理。
+> 安全提示：CLI 默认仅监听回环地址且无认证，仅建议在可信网络内使用。对外网开放时必须显式 `-l http://0.0.0.0:<port>` 并配合 `--serve-token`（所有 API 请求需携带 `X-Serve-Token` 请求头，否则 401）。**注意：API 服务器仅支持 HTTP，`X-Serve-Token` 在局域/公网链路上是明文传输的，token 只提供访问控制、不提供传输加密**——跨不可信网络使用时请务必前置 HTTPS 反向代理（如 nginx/caddy），并避免把 token 写在进程列表可见的明文命令行（可考虑环境变量注入的启动脚本）。`/add-task` 提交的 `host/epHost/tvHost` 仅接受 B 站官方域名、执行路径/代理/工作目录字段一律忽略、请求体上限 64KB。API 服务器不支持 HTTPS。
 
 > 配置注入说明：`serve` 为子命令，其选项（`-l` / `--max-concurrent` / `--serve-token`）**不支持**从配置文件 `BBDown.config` 或环境变量读取，只能通过命令行传入。配置合并（`BBDownConfigParser.MergeWithConfig`）会跳过所有子命令调用，因此 `BBDown.config` 中的选项对 `serve` 不生效。
 

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "10.0.300",
+    "rollForward": "latestPatch",
+    "allowPrerelease": false
+  }
+}


### PR DESCRIPTION
@
## 概述

第四轮深度审查修复（M0 发布安全 + M1 可靠性闭环 + 构建发布项）。**构建 0 警告 0 错误，测试 350 全绿**（新增配置传播/超长分片/请求体上限测试）。

## M0 发布安全与正确性

### AsyncLocal 配置传播无效
用最小运行时程序验证了根因：子异步方法内写 AsyncLocal **不回流父调用方**（三种方式验证均读到父旧值）。
- `TryUpdateWbiKey` 改纯函数 `ExtractWbiKey` 返回新密钥；`CheckLoginWithDetails` 元组增加 `newWbi`，`Workflow.GetVideoInfoAsync` 显式应用
- `BuvidProvider.EnsureAsync` 改返回新 Cookie（`Task<string?>`），`SpaceVideoFetcher` 在自身流程内应用

### 超长分片永久失败循环
`RangeDownloadToTmpAsync` 完成判定前 `SetLength(clipLength)` 截断超长旧分片——此前钳制后直接返回，合并带多余尾部、长度校验失败、重试仍见同一超长分片。新增超长分片回归测试。

### 部分模式零产物成功
SubOnly/VideoOnly无流/AudioOnly无流/DanmakuOnly无弹幕/CoverOnly无封面一律返回 `false`。成功条件统一为"至少生成一个已验证产物"。

## M1 可靠性闭环

### 取消信号断链
`AppHelper.DoReqAsync` 透传 token；FavList/SpaceVideo fetcher 的 `TaskCanceledException` 前先 rethrow 用户取消；评论分支取消先抛再降级。

### 直播分段录制
每段独立文件 + FFmpeg concat 合成（不再追加旧流拼坏文件）；零字节 EOF 计入重试预算 + 指数退避（3s→15s）。

### Serve 请求体上限
64KB（Content-Length + chunked 流式计数），超大 body 返回 400；README 明确 token 不提供传输加密。

### 其他
订阅全败退出码 1、损坏历史警告、DRM 校验 Kid+输出、Parser JsonDocument try/finally、播放 JSON 日志脱敏、Windows 保留名按基名、扩展名大小写不敏感、单线程断点续传、受控跳转复用共享无跳转客户端。

## 构建与发布
Release `DebugType=none`（发布无 PDB）、Package README、`global.json` 锁 SDK、CI 格式检查改硬门禁 + 集成测试 job + Docker 构建/启动冒烟、IL2104 白名单。

## 记录未改
- Ubuntu 18.04 构建容器（glibc 2.27 兼容性刻意保留）
- NuGet 包内 web.config/小型 PDB（Web SDK tool-pack 布局，主发布产物 PDB 瘦身已生效）
@