### PR TITLE
fix: R5 审查批次——mp4box 配音轨丢失、DanmakuOnly 误删分片等 10 项

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# AGENTS.md
+
+## Project
+
+BBDown — command-line Bilibili downloader (C#, .NET 10). Projects:
+- `BBDown/` — CLI app (Spectre.Console.Cli, subcommands in `Commands/`) + API server mode
+- `BBDown.Core/` — engine library: link fetchers (`Fetcher/`), download/mux, Widevine DRM, danmaku, gRPC protos
+- `BBDown.Tests/` — xUnit suite
+
+## Commands
+
+```bash
+dotnet build BBDown.sln -c Release          # CI builds Release
+
+# Unit tests (what PR CI gates on):
+dotnet test BBDown.sln -c Release --no-build --filter "Category!=Integration&Category!=NetworkIntegration&Category!=LocalIntegration"
+
+# Local integration — needs ffmpeg on PATH; tests early-return silently if missing:
+dotnet test BBDown.sln -c Release --filter "Category=LocalIntegration"
+
+# Real-network integration — hits live Bilibili APIs, flaky by nature (non-blocking in CI):
+dotnet test BBDown.sln -c Release --filter "Category=NetworkIntegration"
+
+# Single test class:
+dotnet test --filter "FullyQualifiedName~MuxerArgsTests"
+
+dotnet format BBDown.sln                    # MUST pass --verify-no-changes in CI; run before committing
+
+dotnet publish BBDown -c Release -r win-x64 # Native AOT single-file binary
+
+dotnet run --project BBDown -- --help       # quick manual run
+```
+
+## Hard constraints
+
+- SDK pinned by `global.json` (.NET 10.0.300, rollForward latestPatch).
+- **Native AOT everywhere**: `BBDown/Directory.Build.props` sets `PublishAot=true`. No dynamic reflection; JSON serialization must use source-generator contexts (see `MyOptionJsonContext` in `Program.cs`). Trim/AOT warnings are suppressed via `NoWarn` — do not add reflection casually.
+- **Format gate is hard CI**: UTF-8, LF line endings, 4-space indent, final newline (`.editorconfig`). On Windows, keep new files LF.
+- **`failSkips: true`** in `BBDown.Tests/xunit.runner.json` — `[Fact(Skip = "...")]` fails CI. Guard conditional tests with an early `return` in the body instead (pattern used by ffmpeg tests in `MuxerArgsTests.cs`).
+- Protobuf C# in `BBDown.Core` is generated at build time by Grpc.Tools from `APP/**/*.proto` and `DRM/Proto/*.proto`; edit the `.proto` sources, never generated output.
+- Tests reach internal members via `InternalsVisibleTo("BBDown.Tests")` (set in `BBDown.csproj`).
+
+## Workflow
+
+- `master` is protected — never push directly. Branch prefixes: `feature/`, `fix/`, `refactor/`, `docs/`, `deps/`. Conventional Commits required (`feat:`, `fix(drm):`, …). Details in `CONTRIBUTING.md`.
+- User-facing changes must update docs: `README.md`, `CHANGELOG.md`, and `docs/wiki/` (the GitHub wiki is a separate repo, synced manually via `scripts/sync-wiki.ps1`).
+- Backward compatibility: don't break existing CLI options or `BBDown.config` file format.
+- `serve` subcommand gotchas: its options (`-l`, `--max-concurrent`, `--serve-token`) are never read from `BBDown.config`; non-loopback listen without a token deliberately refuses to start (so bare `docker run` exiting nonzero is expected, not a bug).

--- a/BBDown.Core/Fetcher/BangumiInfoFetcher.cs
+++ b/BBDown.Core/Fetcher/BangumiInfoFetcher.cs
@@ -1,5 +1,6 @@
 using BBDown.Core.Entity;
 using BBDown.Core.Util;
+using System.Globalization;
 using System.Text.Json;
 using static BBDown.Core.Entity.Entity;
 
@@ -28,7 +29,9 @@ public class BangumiInfoFetcher : IFetcher
         string title = result.GetValueAsStringSafe("title");
         string desc = result.GetValueAsStringSafe("evaluate");
         string pubTimeStr = result.TryGetPropertySafe("publish")?.GetValueAsStringSafe("pub_time") ?? "";
-        long pubTime = !string.IsNullOrEmpty(pubTimeStr) && DateTimeOffset.TryParse(pubTimeStr, out var dto) ? dto.ToUnixTimeSeconds() : 0;
+        // InvariantCulture：pub_time 形如 "2021-07-15 11:00:00"，用 CurrentCulture 解析在
+        // 非公历默认历法（fa-IR/ar-SA 等）locale 下会错乱或失败（pubTime 静默归 0）。
+        long pubTime = !string.IsNullOrEmpty(pubTimeStr) && DateTimeOffset.TryParse(pubTimeStr, CultureInfo.InvariantCulture, DateTimeStyles.AllowWhiteSpaces, out var dto) ? dto.ToUnixTimeSeconds() : 0;
         var pages = result.EnumerateArraySafe("episodes");
         List<Page> pagesInfo = new();
         int i = 1;

--- a/BBDown.Core/Fetcher/IntlBangumiInfoFetcher.cs
+++ b/BBDown.Core/Fetcher/IntlBangumiInfoFetcher.cs
@@ -1,5 +1,6 @@
 using BBDown.Core.Entity;
 using BBDown.Core.Util;
+using System.Globalization;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using static BBDown.Core.Entity.Entity;
@@ -52,7 +53,9 @@ public partial class IntlBangumiInfoFetcher : IFetcher
         }
 
         string pubTimeStr = result.TryGetPropertySafe("publish")?.GetValueAsStringSafe("pub_time") ?? "";
-        long pubTime = !string.IsNullOrEmpty(pubTimeStr) && DateTimeOffset.TryParse(pubTimeStr, out var dto) ? dto.ToUnixTimeSeconds() : 0;
+        // InvariantCulture：pub_time 形如 "2021-07-15 11:00:00"，用 CurrentCulture 解析在
+        // 非公历默认历法（fa-IR/ar-SA 等）locale 下会错乱或失败（pubTime 静默归 0）。
+        long pubTime = !string.IsNullOrEmpty(pubTimeStr) && DateTimeOffset.TryParse(pubTimeStr, CultureInfo.InvariantCulture, DateTimeStyles.AllowWhiteSpaces, out var dto) ? dto.ToUnixTimeSeconds() : 0;
         var pages = new List<JsonElement>();
         if (result.TryGetProperty("episodes", out JsonElement episodes))
         {

--- a/BBDown.Core/Parser.cs
+++ b/BBDown.Core/Parser.cs
@@ -15,6 +15,10 @@ public static partial class Parser
 
     public static string WbiSign(string api)
     {
+        // 空 key 产出的 w_rid 必被服务端以 -352 拒绝，而该错误会被上游呈现为"风控"，
+        // 用户无从得知根因是 nav 接口失败导致密钥从未取得——签名前显式告警定位真因。
+        if (string.IsNullOrEmpty(Config.Current.Wbi))
+            Logger.LogWarn("wbi 密钥为空（nav 接口未成功获取），本次签名将被服务端拒绝(-352)，请检查网络后重试");
         return $"{api}&w_rid=" + Convert.ToHexStringLower(MD5.HashData(Encoding.UTF8.GetBytes(api + Config.Current.Wbi)));
     }
 

--- a/BBDown.Core/Util/HTTPUtil.cs
+++ b/BBDown.Core/Util/HTTPUtil.cs
@@ -204,6 +204,11 @@ public static partial class HTTPUtil
     public static async Task<(string Body, List<string> SetCookies)> GetWebSourceWithSetCookiesAsync(
         string url, string? userAgent = null, CancellationToken token = default)
     {
+        // B3-S1 纵深防御与 GetWebSourceCoreAsync(sendCookie:true) 同源收口：本方法携带
+        // 操作者 Cookie（且响应 Set-Cookie 是最敏感的新凭证下发通道），URL 不可信时
+        // 必须在发起任何网络请求前拒绝，防止未来调用方把用户可控 URL 传入导致凭据外发。
+        if (!IsTrustedCookieHost(url))
+            throw new InvalidOperationException($"拒绝向非可信主机发送登录 Cookie: {SensitiveDataMasker.MaskUrl(url)}");
         // 登录轮询（扫码后轮询二维码状态）是 GET，幂等，可安全参与与 GetWebSourceCoreAsync
         // 一致的有界重试：此前零重试会让任一次瞬时 5xx/超时直接中止整个扫码登录流程，
         // 用户必须重新扫码。有界次数 min(MaxRetryCount,3) + 指数退避，见 GetWebSourceCoreAsync。

--- a/BBDown.Tests/CommentUtilTests.cs
+++ b/BBDown.Tests/CommentUtilTests.cs
@@ -51,4 +51,28 @@ public class CommentUtilTests
             if (Directory.Exists(tempRoot)) Directory.Delete(tempRoot, true);
         }
     }
+
+    /// <summary>
+    /// 截断判定回归：末页不满页（如 385 条评论的第 20 页只有 5 条）本身就是末页，
+    /// 不得误标 truncated——否则 UI 对完整数据警告"结果不完整"。
+    /// </summary>
+    [Fact]
+    public void IsTruncated_PartialLastPage_IsNotTruncated()
+    {
+        // 385 条 / 每页 20 条：第 20 页仅 5 条，是自然末页
+        Assert.False(CommentUtil.IsTruncated(pageNumber: 20, maxPages: 20, lastPageItemCount: 5, pageSize: 20));
+    }
+
+    [Fact]
+    public void IsTruncated_FullLastPage_MayHaveMoreComments()
+    {
+        // 第 20 页仍是满页：无法确认后面没有更多，必须标记截断
+        Assert.True(CommentUtil.IsTruncated(pageNumber: 20, maxPages: 20, lastPageItemCount: 20, pageSize: 20));
+    }
+
+    [Fact]
+    public void IsTruncated_BeforeMaxPage_NeverTruncated()
+    {
+        Assert.False(CommentUtil.IsTruncated(pageNumber: 7, maxPages: 20, lastPageItemCount: 20, pageSize: 20));
+    }
 }

--- a/BBDown.Tests/LiveStreamUtilTests.cs
+++ b/BBDown.Tests/LiveStreamUtilTests.cs
@@ -412,6 +412,31 @@ public class LiveStreamUtilTests
     }
 
     /// <summary>
+    /// 不足完整 FLV 头（&lt;13 字节）的垃圾段：TrimFlvTail 无法裁剪（扫描起点就在 13）、
+    /// ffmpeg concat demuxer 会报 Invalid data 中止整场合成。该类段必须与零字节段同等
+    /// 丢弃并退避重连，不能进入分段列表毁掉整场录制。
+    /// </summary>
+    [Fact]
+    public async Task DownloadToFile_TinyHeaderSegment_DeletesGarbageSegmentThenRecordsValidData()
+    {
+        using var server = new FakeLiveServer();
+        server.StreamModes.Enqueue(FakeLiveServer.StreamMode.TinyHeader); // 首段只有 8 字节
+        server.StreamModes.Enqueue(FakeLiveServer.StreamMode.Normal);     // 退避后重连续录
+        server.OfflineAfterStreams = 2;                                   // 录到有效段后下播
+
+        var (result, outPath, dir) = await RunWithServerAsync(server, null, (cts, task) => task);
+
+        Assert.Equal(LiveStreamUtil.LiveRecordResult.Success, result);
+        // 只重连了一次（垃圾段→正常段）
+        Assert.Equal(2, server.StreamRequestCount);
+        // 最终产物只含正常段内容，8 字节垃圾不得并入
+        var saved = await File.ReadAllBytesAsync(outPath);
+        long expected = (long)server.StreamChunkCount * server.StreamChunkBytes;
+        Assert.Equal(expected, saved.Length);
+        try { Directory.Delete(dir, true); } catch { }
+    }
+
+    /// <summary>
     /// 画质请求必须带 qn=30000（最高档，按账号权限回落），而不是低档位——
     /// 配合登录凭据（BBDown.data）才能拿到账号可看的最高画质。
     /// </summary>
@@ -752,6 +777,9 @@ public class LiveStreamUtilTests
             Stall,
             /// <summary>连接建立后立即 EOF、不写任何字节（模拟 CDN 到期/零字节段）。</summary>
             ZeroByte,
+            /// <summary>只写几个字节（不足完整 FLV 头的 13 字节）就 EOF——
+            /// TrimFlvTail 无法裁剪、concat 必然失败的垃圾段。</summary>
+            TinyHeader,
         }
 
         private readonly HttpListener _listener = new();
@@ -842,6 +870,12 @@ public class LiveStreamUtilTests
                             // 零字节 EOF：连接建立后立即结束，不写任何字节。
                             // 客户端应删除空 seg 文件并在直播仍在时退避重连，不能把
                             // “空段”当有效内容并入（F10 未覆盖分支）。
+                            resp.Close();
+                            break;
+                        case StreamMode.TinyHeader:
+                            // 不足完整 FLV 头（13 字节）的垃圾段：响应头后正文被 RST 掐断。
+                            // 客户端必须与零字节段同等丢弃，否则 concat 中止整场合成。
+                            await resp.OutputStream.WriteAsync(new byte[8], _cts.Token);
                             resp.Close();
                             break;
                         case StreamMode.Stall:

--- a/BBDown.Tests/MuxerArgsTests.cs
+++ b/BBDown.Tests/MuxerArgsTests.cs
@@ -162,6 +162,59 @@ public class MuxerArgsTests
     }
 
     /// <summary>
+    /// mp4box 分支必须把配音/背景音轨编入 -add 链：杜比视界 + ffmpeg&lt;5.0 自动切 mp4box 时
+    /// （Download.cs 的 UseMP4box 自动切换），audioMaterial 若不参与混流会被静默丢弃、
+    /// 随后被 CleanupDownloadedTracks 删除——数据永久丢失。轨道名经 -udta 写入。
+    /// </summary>
+    [Fact]
+    public async Task MuxAV_Mp4boxBranch_IncludesAudioMaterialTracks()
+    {
+        var fake = new FakeProcessRunner(exitCode: 0);
+        var original = BBDownMuxer.ProcessRunner;
+        var tempDir = NewTempDir();
+        try
+        {
+            BBDownMuxer.ProcessRunner = fake;
+
+            var videoPath = Path.Combine(tempDir, "video.mp4");
+            var audioPath = Path.Combine(tempDir, "audio.m4a");
+            var bgPath = Path.Combine(tempDir, "bg.m4a");
+            var rolePath = Path.Combine(tempDir, "role.m4a");
+            File.WriteAllText(videoPath, "v");
+            File.WriteAllText(audioPath, "a");
+            File.WriteAllText(bgPath, "b");
+            File.WriteAllText(rolePath, "r");
+            var outPath = Path.Combine(tempDir, "out.mp4");
+
+            var audioMaterial = new List<AudioMaterial>
+            {
+                new("背景音频", "", bgPath),
+                new("", "配音演员", rolePath), // 无 title 时回落 personName 作轨道名
+            };
+
+            // useMp4box: true 走 mp4box 分支（假 runner 下 EnsureToolAvailable 跳过校验）
+            await BBDownMuxer.MuxAV(true, "BVtest", videoPath, audioPath, audioMaterial, outPath);
+
+            var args = fake.Specs.Single(s => s.FileName == "mp4box").Arguments;
+
+            // 每个素材都必须以 -add <path>:lang=und 进入混流链
+            Assert.Contains("-add", args);
+            Assert.Contains($"{bgPath}:lang=und", args);
+            Assert.Contains($"{rolePath}:lang=und", args);
+
+            // 轨道名：title 优先，缺失时回落 personName；-udta 值按加入顺序编号
+            // 输入序列 video(1) / audio(2) / bg(3) / role(4)
+            Assert.Equal("3:type=name:str=\"背景音频\"", args[args.IndexOf("-udta") + 1]);
+            Assert.Contains("4:type=name:str=\"配音演员\"", args);
+        }
+        finally
+        {
+            BBDownMuxer.ProcessRunner = original;
+            CleanupDir(tempDir);
+        }
+    }
+
+    /// <summary>
     /// 字幕下标快照测试：跳过空/缺失字幕文件后，-metadata:s:s:N 的 N 应连续递增
     /// （第一条有效字幕为 s:0、第二条为 s:1），不得沿用原列表下标——首项被跳过时
     /// 沿用 i 会把元数据写到 s:1/s:2，与真实字幕流错位。

--- a/BBDown/Application/Download.cs
+++ b/BBDown/Application/Download.cs
@@ -630,7 +630,10 @@ internal partial class Program
                                     relatedTask?.AddSavePath(danmakuAssPath);
                                     danmakuProduced = true;
                                 }
-                                if (Directory.Exists(PathUtil.ResolveWorkPath(p.aid)))
+                                // 只清理空目录：非空意味着存在上次中断留下的可续传分片
+                                // （.vclip/.aclip 等，设计上保留）或并发任务的产物，
+                                // 递归删除会把它们一起毁掉（与 SubOnly/CoverOnly 同一守卫语义）。
+                                if (Directory.Exists(PathUtil.ResolveWorkPath(p.aid)) && Directory.GetFiles(PathUtil.ResolveWorkPath(p.aid)).Length == 0)
                                 {
                                     try { Directory.Delete(PathUtil.ResolveWorkPath(p.aid), true); } catch (IOException) { }
                                 }
@@ -909,7 +912,8 @@ internal partial class Program
                                     relatedTask?.AddSavePath(danmakuAssPath);
                                     danmakuProduced = true;
                                 }
-                                if (Directory.Exists(PathUtil.ResolveWorkPath(p.aid)))
+                                // 只清理空目录（守卫语义同上方 DanmakuOnly 第一处：保留可续传分片）
+                                if (Directory.Exists(PathUtil.ResolveWorkPath(p.aid)) && Directory.GetFiles(PathUtil.ResolveWorkPath(p.aid)).Length == 0)
                                 {
                                     try { Directory.Delete(PathUtil.ResolveWorkPath(p.aid), true); } catch (IOException) { }
                                 }
@@ -944,7 +948,9 @@ internal partial class Program
                         {
                             Logger.Log($"{savePath}已存在, 跳过下载...");
                             relatedTask?.AddSavePath(savePath);
-                            if (selectedPagesInfo.Count == 1 && Directory.Exists(PathUtil.ResolveWorkPath(p.aid)))
+                            // 只清理空目录：目录里的可续传分片可能属于其它分P的上次中断下载
+                            // （aid 工作目录按稿件共享），不能因本P跳过而连带删除。
+                            if (selectedPagesInfo.Count == 1 && Directory.Exists(PathUtil.ResolveWorkPath(p.aid)) && Directory.GetFiles(PathUtil.ResolveWorkPath(p.aid)).Length == 0)
                             {
                                 try { Directory.Delete(PathUtil.ResolveWorkPath(p.aid), true); } catch (IOException) { }
                             }

--- a/BBDown/Commands/ArticleCommand.cs
+++ b/BBDown/Commands/ArticleCommand.cs
@@ -36,11 +36,14 @@ public class ArticleCommand : Command<ArticleSettings>
                 string cvId = ArticleUtil.ExtractCvId(settings.CvId);
                 Logger.Log($"正在获取专栏 cv{cvId}...");
                 var article = await ArticleUtil.FetchAsync(cvId, cancellationToken);
-                // 专栏默认输出目录尊重 --work-dir（与主下载命令一致）；
-                // 显式 --output 为绝对路径时不受影响（Path.Combine 对已根化第二参数直接透传）。
+                // 专栏默认输出目录尊重 --work-dir（与主下载命令一致）。
+                // 相对 --output 同样相对 --work-dir 解析（Path.Combine 对已根化第二参数
+                // 直接透传，绝对路径不受影响）；workDir 为空串时保持 CWD 语义。
                 // 用纯函数 ResolveWorkDir：仅解析/建目录，不切进程 CWD（无全局副作用）。
                 string workDir = Program.ResolveWorkDir(settings.WorkDir);
-                string path = settings.Output ?? Path.Combine(workDir, $"{LiveStreamUtil.SanitizeFileName(article.Title)}.md");
+                string path = settings.Output is null
+                    ? Path.Combine(workDir, $"{LiveStreamUtil.SanitizeFileName(article.Title)}.md")
+                    : Path.Combine(workDir, settings.Output);
                 await ArticleUtil.SaveAsMarkdownAsync(article, path);
                 Logger.Log($"专栏已保存: {path}");
                 return 0;

--- a/BBDown/Commands/LiveCommand.cs
+++ b/BBDown/Commands/LiveCommand.cs
@@ -64,11 +64,15 @@ public class LiveCommand : Command<LiveSettings>
                 Logger.Log($"正在解析直播间 {settings.RoomId}...");
                 var info = await LiveStreamUtil.ResolveAsync(settings.RoomId, cancellationToken);
                 Logger.Log($"直播间: {info.Title} (UP: {info.Uname})，画质: {LiveStreamUtil.QualityName(info.Quality)} (qn={info.Quality})");
-                // 直播录制默认输出目录尊重 --work-dir（与主下载命令一致）；
-                // 显式 --output 为绝对路径时不受影响。用纯函数 ResolveWorkDir：
-                // 仅解析/建目录，不切进程 CWD（.segs 分段目录随输出路径派生，也同步落 workDir）。
+                // 直播录制默认输出目录尊重 --work-dir（与主下载命令一致）。
+                // 相对 --output 同样相对 --work-dir 解析（Path.Combine 对已根化第二参数
+                // 直接透传，绝对路径不受影响）；workDir 为空串时保持 CWD 语义。
+                // 用纯函数 ResolveWorkDir：仅解析/建目录，不切进程 CWD（无全局副作用），
+                // .segs 分段目录随输出路径派生，也同步落 workDir。
                 string workDir = Program.ResolveWorkDir(settings.WorkDir);
-                string path = settings.Output ?? Path.Combine(workDir, $"{LiveStreamUtil.SanitizeFileName(info.Title)}_直播录制_{DateTime.Now:yyyyMMdd_HHmmss}.flv");
+                string path = settings.Output is null
+                    ? Path.Combine(workDir, $"{LiveStreamUtil.SanitizeFileName(info.Title)}_直播录制_{DateTime.Now:yyyyMMdd_HHmmss}.flv")
+                    : Path.Combine(workDir, settings.Output);
                 Logger.Log($"开始录制直播流: {path} (Ctrl+C 停止；断流/网络中断自动重连续录)");
 
                 DateTime lastLog = DateTime.MinValue;

--- a/BBDown/Infrastructure/BBDownDownloadUtil.cs
+++ b/BBDown/Infrastructure/BBDownDownloadUtil.cs
@@ -607,11 +607,11 @@ internal static class BBDownDownloadUtil
                 {
                     Logger.LogDebug("文件已下载过, 跳过下载");
                     DeleteResumeManifest(path);
-                    var vclipDir = path + ".vclip";
-                    if (Directory.Exists(vclipDir))
-                    {
-                        try { Directory.Delete(vclipDir, true); } catch { }
-                    }
+                    // 成品已完整时，历史中断遗留的合并临时文件（GB 级）与分片不再有任何
+                    // 消费者——CleanStaleClipsFor 只清 *_<stem>.vclip/.aclip 分片文件，
+                    // .merging 不在其匹配范围内，必须在此显式清理，否则永久泄漏磁盘。
+                    CleanStaleClipsFor(path);
+                    DeleteStaleMergeTmp(path);
                     return;
                 }
                 Logger.LogDebug("探测大小({0})与权威大小({1})不符，既有文件不可信，删除后完整重下", fileSize, known);
@@ -864,6 +864,18 @@ internal static class BBDownDownloadUtil
             try { clip.Delete(); }
             catch (IOException) { /* 并发占用时跳过，下次运行再清理 */ }
         }
+    }
+
+    /// <summary>
+    /// 删除历史中断遗留的合并临时文件（<paramref name="path"/> + ".merging"）。
+    /// 成品路径已完整时该文件无任何消费者（重下会经 File.Create 截断自愈），
+    /// 但"跳过下载"路径不会走到合并步骤——不显式清理就永久泄漏磁盘。
+    /// </summary>
+    private static void DeleteStaleMergeTmp(string path)
+    {
+        var merging = path + ".merging";
+        try { if (File.Exists(merging)) File.Delete(merging); }
+        catch (IOException) { /* 占用中：下次运行再清理 */ }
     }
 
     //此函数主要是切片下载逻辑

--- a/BBDown/Infrastructure/BBDownMuxer.cs
+++ b/BBDown/Infrastructure/BBDownMuxer.cs
@@ -52,7 +52,11 @@ static partial class BBDownMuxer
             ? File.Exists(tool)
             : ExternalToolHelper.FindExecutable(tool) is not null;
         if (!available)
-            throw new FileNotFoundException(
+            // InvalidOperationException 而非 FileNotFoundException：本异常可能从
+            // MergeFLV/MuxByMp4box 冒泡到分P批量循环，页面级与批级的失败上报 catch 过滤器
+            // 均不含 FileNotFoundException——用工具缺失逃逸会跳过剩余分P、webhook 与
+            // failedPages 汇总；InvalidOperationException 已在两处过滤器内，走统一失败上报。
+            throw new InvalidOperationException(
                 $"找不到可执行的{tool}文件（{purpose}）。请安装并加入 PATH，或使用 {toolFlag} 指定路径。");
     }
 
@@ -66,7 +70,7 @@ static partial class BBDownMuxer
             : str.Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("\r", " ").Replace("\n", " ");
     }
 
-    private static async Task<int> MuxByMp4box(string url, string videoPath, string audioPath, string outPath, string desc, string title, string author, string episodeId, string pic, string lang, List<Subtitle>? subs, bool audioOnly, bool videoOnly, List<ViewPoint>? points, CancellationToken cancellationToken)
+    private static async Task<int> MuxByMp4box(string url, string videoPath, string audioPath, List<AudioMaterial>? audioMaterial, string outPath, string desc, string title, string author, string episodeId, string pic, string lang, List<Subtitle>? subs, bool audioOnly, bool videoOnly, List<ViewPoint>? points, CancellationToken cancellationToken)
     {
         // 杜比视界自动切 mp4box 时 FindBinaries 只探了 ffmpeg（初始 UseMP4box=false），
         // MP4BOX 从未探测：这里运行时守卫给出清晰报错，替代原生 Win32Exception。
@@ -102,6 +106,22 @@ static partial class BBDownMuxer
             args.Add("-add");
             args.Add($"{audioPath}:lang={(lang == "" ? "und" : lang)}");
             nowId++;
+        }
+        // 配音/背景音轨与 ffmpeg 分支对齐：必须进入 -add 链。否则杜比视界自动切 mp4box
+        // （ffmpeg<5.0）时这些已下载的轨道被静默丢弃，且随后被 CleanupDownloadedTracks
+        // 删除——数据永久丢失且无任何警告。
+        foreach (var material in audioMaterial ?? [])
+        {
+            args.Add("-add");
+            args.Add($"{material.path}:lang=und");
+            nowId++;
+            var name = !string.IsNullOrWhiteSpace(material.title) ? material.title : material.personName;
+            if (!string.IsNullOrWhiteSpace(name))
+            {
+                // 轨道名走 -udta（与下方字幕轨道同机制）；mp4box 的值语法要求转义。
+                args.Add("-udta");
+                args.Add($"{nowId}:type=name:str=\"{EscapeString(name)}\"");
+            }
         }
         string? metaFile = null;
         try
@@ -189,7 +209,7 @@ static partial class BBDownMuxer
 
         if (useMp4box)
         {
-            return await MuxByMp4box(url, videoPath, audioPath, outPath, desc, title, author, episodeId, pic, lang, subs, audioOnly, videoOnly, points, cancellationToken);
+            return await MuxByMp4box(url, videoPath, audioPath, audioMaterial, outPath, desc, title, author, episodeId, pic, lang, subs, audioOnly, videoOnly, points, cancellationToken);
         }
 
         string? metaFile = null;

--- a/BBDown/Infrastructure/CommentUtil.cs
+++ b/BBDown/Infrastructure/CommentUtil.cs
@@ -31,11 +31,12 @@ public static class CommentUtil
     /// </summary>
     public static async Task<CommentPage> FetchAsync(long aid, int maxPages = 20, CancellationToken token = default)
     {
+        const int pageSize = 20;
         var result = new List<CommentItem>();
         bool truncated = false;
         for (int pn = 1; pn <= maxPages; pn++)
         {
-            string api = $"https://api.bilibili.com/x/v2/reply?type=1&oid={aid}&sort=0&ps=20&pn={pn}";
+            string api = $"https://api.bilibili.com/x/v2/reply?type=1&oid={aid}&sort=0&ps={pageSize}&pn={pn}";
             string json = await HTTPUtil.GetWebSourceAsync(api, token: token);
             using var doc = JsonDocument.Parse(json);
             var root = doc.RootElement;
@@ -46,6 +47,7 @@ public static class CommentUtil
             if (dataElem is null) break;
             var replies = dataElem.Value.EnumerateArraySafe("replies");
             if (!replies.Any()) break;
+            int addedThisPage = 0;
             foreach (var r in replies)
             {
                 var member = r.TryGetPropertySafe("member");
@@ -55,12 +57,21 @@ public static class CommentUtil
                     r.GetInt64Safe("ctime"),
                     r.GetInt64Safe("like"),
                     content.Trim()));
+                addedThisPage++;
             }
-            // 已达到分页上限但当前页仍有回复：说明还有更多评论未抓取
-            if (pn == maxPages) truncated = true;
+            // 已达分页上限且最后一页是满页：才可能还有更多评论。不满页（如 385 条的第 20 页
+            // 只有 5 条）本身就是末页——按页序号判定会把完整结果误标为截断。
+            if (IsTruncated(pn, maxPages, addedThisPage, pageSize)) truncated = true;
         }
         return new CommentPage(result, truncated);
     }
+
+    /// <summary>
+    /// 截断判定（internal 供回归测试）：仅当到达分页上限且最后一页是满页时，
+    /// 才可能存在未抓取的后续评论；末页不满页即数据自然耗尽，不算截断。
+    /// </summary>
+    internal static bool IsTruncated(int pageNumber, int maxPages, int lastPageItemCount, int pageSize)
+        => pageNumber == maxPages && lastPageItemCount >= pageSize;
 
     /// <summary>评论抓取结果：列表 + 是否因达到分页上限而被截断（存在未抓取的更多评论）。</summary>
     public record CommentPage(List<CommentItem> Items, bool Truncated);

--- a/BBDown/Infrastructure/LiveStreamUtil.cs
+++ b/BBDown/Infrastructure/LiveStreamUtil.cs
@@ -182,6 +182,10 @@ public static class LiveStreamUtil
     /// <summary>短段中断连续达到该次数后套用退避：否则病态 CDN 下无退避紧循环每秒数次
     /// 调 getRoomPlayInfo，长时间可能触发 B 站风控。</summary>
     private const int MaxConsecutiveShortSegments = 3;
+    /// <summary>最小完整 FLV 文件头长度：FLV 头 9 字节 + PreviousTagSize0 恒 4 字节。
+    /// 不足该长度的段连文件头都不完整——TrimFlvTail 无法裁剪（扫描起点就在 13），
+    /// 喂给 ffmpeg concat demuxer 会报 Invalid data 中止整场合成，必须与零字节段同等丢弃。</summary>
+    private const int MinCompleteFlvHeaderBytes = 13;
 
     /// <summary>
     /// 录制直播流到文件。如果发生断流且房间仍在直播，会自动重连并生成多个分段，
@@ -258,7 +262,10 @@ public static class LiveStreamUtil
                     var (segBytes, readInterrupted) = await StreamToFileAsync(url, segPath, total, onProgress, token, readStallTimeout);
                     if (readInterrupted) Logger.LogDebug("直播流连接在读取时中断，已写入 {0} 字节", segBytes);
 
-                    if (segBytes > 0)
+                    // 段有效下限 = MinCompleteFlvHeaderBytes：< 13 字节的段连 FLV 文件头都不完整
+                    // （TrimFlvTail 无法裁剪、concat 必然失败），与零字节段同等处理。
+                    // 取消场景同理：丢弃的至多是 < 13 字节的垃圾字节，不影响"已录内容照常保存"。
+                    if (segBytes >= MinCompleteFlvHeaderBytes)
                     {
                         // 本段有内容（含"读到数据后中断"的部分段与取消时已写段）：计入已录内容。
                         segmentFiles.Add(segPath);
@@ -290,11 +297,11 @@ public static class LiveStreamUtil
                         break;
                     }
 
-                    // 零字节段：连接刚建立就结束。若直播仍进行，这是连接到期/CDN 切换，
+                    // 零字节/头部不完整段：连接刚建立就结束。若直播仍进行，这是连接到期/CDN 切换，
                     // 退避后重连，避免高速轮询。
-                    try { File.Delete(segPath); } catch (IOException) { }
+                    try { File.Delete(segPath); } catch (Exception ex) when (ex is IOException or UnauthorizedAccessException) { }
                     if (!await IsRoomLiveAsync()) break; // 确认下播：结束录制
-                    Logger.LogWarn("直播流连接立即结束但直播间仍在直播，正在退避后重连...");
+                    Logger.LogWarn($"直播流连接立即结束（收到 {segBytes} 字节，不足完整 FLV 头）但直播间仍在直播，正在退避后重连...");
                     await BackoffAsync(new IOException("直播流零字节 EOF"));
                 }
                 catch (OperationCanceledException) when (token.IsCancellationRequested)


### PR DESCRIPTION
## 描述
R5 审查批次（R1-R4 结项后复查 + 新鲜视角核心模块审查）确认的 10 项缺陷修复：4 Medium（mp4box 配音轨静默丢失、DanmakuOnly 误删可续传分片、live/article 相对输出与 work-dir 语义不符、直播垃圾短段毁掉整场合成）+ 6 Low/Medium-Low（.merging 磁盘泄漏、pub_time 文化敏感解析、cookie 白名单收口、WBI 空 key 误诊、评论截断误报、工具缺失异常逃逸批量上报），另附 AGENTS.md 代理协作指引。

## 改动类型
- [x] Bug 修复
- [x] 文档更新

## 检查清单
- [x] `dotnet build` 在本地通过（0 Error，0 Warning）
- [x] `dotnet test` 通过（619 单元 + 3 LocalIntegration 全绿）
- [x] `dotnet format --verify-no-changes` 通过
- [x] 已同步更新相关文档（AGENTS.md 新增；本批为纯缺陷修复，无用户可见行为变更需更新 README 的条目——live/article 相对 --output 落 work-dir 属帮助文本既有语义的兑现）

## 测试说明
- 新增 6 例回归：mp4box 参数断言素材 -add 链与 -udta 轨道名；假服务器 TinyHeader 流模式验证垃圾段丢弃后退避续录且产物无垃圾字节；IsTruncated 满/不满页/未达上限 3 判定
- 全量单元测试 619/619 通过，本机 ffmpeg LocalIntegration 3/3 通过（含字幕 language 元数据 ffprobe 验证）

## 提交拆分
1. fix(muxer): mp4box 分支编入配音轨 + 工具缺失异常类型
2. fix(download): 只读模式删目录守卫 + .merging 清理
3. fix(live): 垃圾短段丢弃 + live/article 相对输出落 work-dir
4. fix(core): 凭据门收口 / InvariantCulture / WBI 告警 / 截断误报
5. docs: AGENTS.md