### PR TITLE
fix(review): 第 9 轮——消纳挂起发现 RF-4/RF-5/RF-6/RF-7

### DIFF
--- a/BBDown.Core/DRM/WidevineCdm.cs
+++ b/BBDown.Core/DRM/WidevineCdm.cs
@@ -220,9 +220,18 @@ public sealed class WidevineCdm : IDisposable
                 req.Headers.TryAddWithoutValidation("Referer", "https://www.bilibili.com");
                 req.Headers.TryAddWithoutValidation("Accept", "*/*");
 
-                // 许可证响应携带内容解密密钥：强制走始终校验证书的客户端（VerifiedAppHttpClient），
-                // 不受用户 --insecure 影响——跳过 TLS 校验会让中间人直接窃取内容密钥。
-                using var resp = await HTTPUtil.VerifiedAppHttpClient.SendAsync(req, token);
+                // 许可证响应携带内容解密密钥、请求体是设备私钥签名的 challenge：
+                // 强制走始终校验证书的客户端（VerifiedNoRedirectClient），不受用户 --insecure
+                // 影响——跳过 TLS 校验会让中间人直接窃取内容密钥；同时禁自动跟随重定向
+                // （RF-4）：AllowAutoRedirect=true 会在 307/308 上连同 body 重放到跨主机目标，
+                // 签名载荷随跳转外发。3xx 在此显式拦下报错，不跟随、不外发（与 gRPC POST 同构）。
+                using var resp = await HTTPUtil.VerifiedNoRedirectClient.SendAsync(req, token);
+                // 3xx：许可证端点不应重定向，显式拦截（不允许 challenge/body 随 307/308 重放）。
+                // 状态码 <500 不满足重试谓词，按确定性失败立即抛出。
+                if ((int)resp.StatusCode is >= 300 and < 400)
+                    throw new HttpRequestException(
+                        $"许可证端点返回意外重定向 (HTTP {(int)resp.StatusCode})，已拒绝跟随以避免签名请求体外发",
+                        null, resp.StatusCode);
                 if (!resp.IsSuccessStatusCode)
                 {
                     // 5xx 瞬时故障参与有界重试；4xx 确定性失败立即抛（带状态码供上层定位）

--- a/BBDown.Core/Util/HTTPUtil.cs
+++ b/BBDown.Core/Util/HTTPUtil.cs
@@ -73,6 +73,19 @@ public static partial class HTTPUtil
     /// </summary>
     public static HttpClient VerifiedAppHttpClient => _appHttpClient.Value;
 
+    // 始终校验 + 禁自动跳转的专用池：与 _appHttpClient 同超时、同校验策略，仅重定向策略不同。
+    private static readonly Lazy<HttpClient> _verifiedNoRedirectClient =
+        new(() => CreateClient(allowRedirect: false, TimeSpan.FromMinutes(2), skipSslCheck: false), LazyThreadSafetyMode.ExecutionAndPublication);
+
+    /// <summary>
+    /// 始终校验证书且禁自动跟随重定向的共享客户端：供携带签名载荷的非幂等请求使用
+    /// （WidevineCdm 许可证 POST）。VerifiedAppHttpClient（AllowAutoRedirect=true）会把
+    /// 307/308 连同 body 重放到跨主机目标——许可证请求体是设备私钥签名的 challenge，
+    /// 随重定向重放即签名外发；此处 3xx 由调用方显式拦截（与 gRPC POST 的 B3-F2 收口同构）。
+    /// 与 VerifiedAppHttpClient 同样不受 --insecure 影响（独立于不安全池，不能由用户选项降级）。
+    /// </summary>
+    public static HttpClient VerifiedNoRedirectClient => _verifiedNoRedirectClient.Value;
+
     /// <summary>
     /// 媒体下载专用客户端：禁用自动跟随重定向（B3-F3）。下载请求携带登录 Cookie，
     /// 且 URL 由 B 站播放接口（受信任源）返回——若开启自动跳转，一个被篡改/被攻破的
@@ -730,7 +743,7 @@ public static partial class HTTPUtil
             {
                 // 本函数仅服务幂等查询（PlayView gRPC 播放地址、字幕 gRPC）：重发不改变
                 // 服务端状态，连接级失败（StatusCode null）与 5xx 均可安全有界重试。
-                // 真正的非幂等请求（Widevine 许可证）走 VerifiedAppHttpClient 直连
+                // 真正的非幂等请求（Widevine 许可证）走 VerifiedNoRedirectClient 直连
                 // （WidevineCdm.cs），不经过本函数的重试逻辑。
                 int backoffMs = ExponentialBackoffMs(attempt);
                 Logger.LogDebug("API POST 失败(第{0}次重试, {1}ms后): {2}", attempt, backoffMs, SensitiveDataMasker.MaskUrl(Url));

--- a/BBDown.Tests/ConfigMergeTests.cs
+++ b/BBDown.Tests/ConfigMergeTests.cs
@@ -114,4 +114,43 @@ public class ConfigMergeTests
         Assert.Single(merged, a => a.StartsWith("https://"));
         Assert.Contains("--dfn-priority", merged);
     }
+
+    [Fact]
+    public void UrlLikeOptionValue_DoesNotSuppressConfigUrl()
+    {
+        // RF-7 回归：--aria2c-proxy 的值（http://127.0.0.1:7890）形似 URL。
+        // 旧实现对全部 argv 应用 URL 启发式，"URL 在配置文件 + 命令行有 URL 形值选项"
+        // 被误判成"命令行已给出 URL"，配置文件里的 URL 被丢弃 → Spectre 报缺少必填参数。
+        var cfg = WriteConfig("https://www.bilibili.com/video/BV1AAAAAAAAAA\n--dfn-priority\n1080P 高清\n");
+        var merged = BBDownConfigParser.MergeWithConfig(
+            ["--config-file", cfg, "--aria2c-proxy", "http://127.0.0.1:7890"]);
+        File.Delete(cfg);
+
+        Assert.Contains("https://www.bilibili.com/video/BV1AAAAAAAAAA", merged);
+        Assert.Equal("1080P 高清", EffectiveValue(merged, "--dfn-priority"));
+        Assert.Equal("http://127.0.0.1:7890", EffectiveValue(merged, "--aria2c-proxy"));
+    }
+
+    [Fact]
+    public void IdLikeOptionValue_DoesNotSuppressConfigUrl()
+    {
+        // 同 RF-7：--work-dir av123 的值命中 av\d+ 形态，同样不应算作"命令行已给 URL"
+        var cfg = WriteConfig("https://www.bilibili.com/video/BV1AAAAAAAAAA\n");
+        var merged = BBDownConfigParser.MergeWithConfig(
+            ["--config-file", cfg, "--work-dir", "av123"]);
+        File.Delete(cfg);
+
+        Assert.Contains("https://www.bilibili.com/video/BV1AAAAAAAAAA", merged);
+        Assert.Equal("av123", EffectiveValue(merged, "--work-dir"));
+    }
+
+    [Fact]
+    public void GetPositionalTokens_SkipsOptionValues()
+    {
+        // 需要值的选项吞掉下一 token；bool 开关与 "--opt=value" 不吞；
+        // 只有真正的位置参数（URL 候选）被收集
+        Assert.Equal(["URL"], BBDownConfigParser.GetPositionalTokens(
+            ["--config-file", "x.config", "--debug", "--aria2c-proxy=http://127.0.0.1:7890", "-p", "2", "URL"]));
+        Assert.Empty(BBDownConfigParser.GetPositionalTokens(["--aria2c-proxy", "http://127.0.0.1:7890"]));
+    }
 }

--- a/BBDown.Tests/VerifiedNoRedirectClientTests.cs
+++ b/BBDown.Tests/VerifiedNoRedirectClientTests.cs
@@ -1,0 +1,134 @@
+using System.Net;
+using BBDown.Core;
+using BBDown.Core.Util;
+
+namespace BBDown.Tests;
+
+/// <summary>
+/// RF-4：Widevine 许可证请求的传输通道。VerifiedNoRedirectClient 必须同时满足
+/// ① 始终校验证书（不随 --insecure 降级——响应携带内容密钥）；② 禁自动跟随重定向
+/// （请求体是设备私钥签名的 challenge，307/308 连同 body 重放即签名外发）。
+/// </summary>
+public class VerifiedNoRedirectClientTests
+{
+    [Fact]
+    public void VerifiedNoRedirectClient_AlwaysVerified_RegardlessOfFlowConfig()
+    {
+        var original = Config.Current.SkipSslCheck;
+        try
+        {
+            // 即使当前流跳过了校验，VerifiedNoRedirectClient 仍指向始终校验的池
+            //（不能由用户选项降级，同 VerifiedAppHttpClient 的安全前提）
+            Config.ApplyToCurrentAsyncFlow(Config.Current with { SkipSslCheck = true });
+            var verified = HTTPUtil.VerifiedNoRedirectClient;
+            Config.ApplyToCurrentAsyncFlow(Config.Current with { SkipSslCheck = false });
+            Assert.Same(verified, HTTPUtil.VerifiedNoRedirectClient);
+        }
+        finally
+        {
+            Config.ApplyToCurrentAsyncFlow(Config.Current with { SkipSslCheck = original });
+        }
+    }
+
+    [Fact]
+    public async Task VerifiedNoRedirectClient_DoesNotFollowRedirect_WhileAutoRedirectClientDoes()
+    {
+        using var server = new SingleRedirectServer();
+        var url = $"http://127.0.0.1:{server.Port}/start";
+
+        // 禁自动跳转：3xx 作为响应直接返回，Location 指向的目标不会被请求
+        using (var resp = await HTTPUtil.VerifiedNoRedirectClient.GetAsync(url))
+        {
+            Assert.Equal(HttpStatusCode.TemporaryRedirect, resp.StatusCode);
+        }
+        Assert.Equal(1, server.RequestCount);
+
+        // 对照组：自动跳转客户端（VerifiedAppHttpClient）会跟随到终态——
+        // 正是 RF-4 要在许可证链路上排除的行为。
+        // 计数包含上一阶段的 1 次：/start（307）+ /final（200）共再增 2 次，总计 3
+        using (var resp = await HTTPUtil.VerifiedAppHttpClient.GetAsync(url))
+        {
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        }
+        Assert.Equal(3, server.RequestCount);
+    }
+
+    [Fact]
+    public async Task VerifiedNoRedirectClient_PostWithBody_RedirectIsReturnedNotFollowed()
+    {
+        // 镜像许可证请求形态（POST + 签名 body）：307 不被跟随，body 只到达服务端一次，
+        // 由调用方拿到 3xx 显式处置（WidevineCdm 拦截报错），不存在重放外发
+        using var server = new SingleRedirectServer();
+        var url = $"http://127.0.0.1:{server.Port}/start";
+
+        using var content = new StringContent("signed-challenge-body");
+        using var resp = await HTTPUtil.VerifiedNoRedirectClient.PostAsync(url, content);
+
+        Assert.Equal(HttpStatusCode.TemporaryRedirect, resp.StatusCode);
+        Assert.Equal(1, server.RequestCount);
+    }
+
+    /// <summary>起一个本地 HTTP 服务：/start 返回 307 重定向到 /final（终态 200），统计实际收到的请求数。</summary>
+    private sealed class SingleRedirectServer : IDisposable
+    {
+        private readonly HttpListener _listener = new();
+        private readonly CancellationTokenSource _cts = new();
+        private readonly Task _loop;
+
+        public int Port { get; }
+
+        // 服务端实际处理的请求总数：区分"3xx 被直接返回"（1 次）与"被跟随"（≥2 次）
+        private int _requestCount;
+        public int RequestCount => Volatile.Read(ref _requestCount);
+
+        public SingleRedirectServer()
+        {
+            // 动态分配空闲回环端口：固定端口段在 CI 并行/端口冲突时 HttpListener.Start 直接失败
+            var port = TestPort.Allocate();
+            _listener.Prefixes.Add($"http://127.0.0.1:{port}/");
+            _listener.Start();
+            Port = port;
+            _loop = Task.Run(async () =>
+            {
+                try
+                {
+                    while (!_cts.IsCancellationRequested)
+                    {
+                        var ctx = await _listener.GetContextAsync();
+                        try
+                        {
+                            Interlocked.Increment(ref _requestCount);
+                            if (ctx.Request.Url!.AbsolutePath == "/final")
+                            {
+                                ctx.Response.StatusCode = 200;
+                            }
+                            else
+                            {
+                                ctx.Response.StatusCode = 307;
+                                ctx.Response.RedirectLocation = "/final";
+                            }
+                            ctx.Response.Close();
+                        }
+                        catch
+                        {
+                            // 客户端中止连接等：忽略
+                        }
+                    }
+                }
+                catch (HttpListenerException)
+                {
+                    // 服务停止
+                }
+            });
+        }
+
+        public void Dispose()
+        {
+            _cts.Cancel();
+            try { _listener.Stop(); } catch { }
+            _listener.Close();
+            try { _loop.Wait(TimeSpan.FromSeconds(2)); } catch { }
+            _cts.Dispose();
+        }
+    }
+}

--- a/BBDown/Configuration/BBDownConfigParser.cs
+++ b/BBDown/Configuration/BBDownConfigParser.cs
@@ -63,6 +63,36 @@ internal static partial class BBDownConfigParser
         return false;
     }
 
+    /// <summary>
+    /// 提取命令行中的位置参数（即下载 URL 的候选位置）。识别"已显式给出 URL"时
+    /// 只扫位置参数、不扫全部 argv：选项的值可能恰好形似 URL（如
+    /// --aria2c-proxy http://127.0.0.1:7890、--work-dir av123），把"URL 在配置文件 +
+    /// 命令行有 URL 形值选项"误判成"命令行已给出 URL"，配置文件里的 URL 被丢弃后
+    /// Spectre 报缺少必填参数，用户难以定位（RF-7）。
+    /// 与 <see cref="IsSubCommandInvocation"/> 同构：需要值的选项吞掉下一 token，
+    /// bool 开关与 "--opt=value" 写法不吞。
+    /// </summary>
+    internal static List<string> GetPositionalTokens(string[] args)
+    {
+        var aliasMap = BuildAliasMap();
+        var positionals = new List<string>();
+        for (int i = 0; i < args.Length; i++)
+        {
+            var arg = args[i];
+            if (!arg.StartsWith('-'))
+            {
+                positionals.Add(arg);
+                continue;
+            }
+            var token = arg;
+            var eq = token.IndexOf('=');
+            if (eq > 0) continue; // "--opt=value"：值已含在 token 内，不消耗下一项
+            if (aliasMap.TryGetValue(token, out var canonical) && !FlagOptionCanonicals.Contains(canonical))
+                i++; // 该选项需要值：下一 token 是它的值，跳过
+        }
+        return positionals;
+    }
+
     public static List<string> MergeWithConfig(string[] cliArgs)
     {
         var result = new List<string>(cliArgs);
@@ -133,7 +163,9 @@ internal static partial class BBDownConfigParser
         // 命令行已显式给出 URL 时，配置文件里的位置参数（URL）不再合并，
         // 否则 MyOption 只声明一个 <URL> 位置参数，Spectre 会报 unexpected positional argument。
         // 与"命令行显式给出的选项必须压过配置文件"的合并原则保持一致。
-        bool cliHasUrl = cliArgs.Any(a => UrlLikeToken().IsMatch(a));
+        // 只对位置参数应用 URL 启发式（RF-7）：全量扫描会把选项值（--aria2c-proxy 的
+        // 代理地址、--work-dir 的 av123 等）误判为 URL，丢弃配置文件里的真实 URL。
+        bool cliHasUrl = GetPositionalTokens(cliArgs).Any(a => UrlLikeToken().IsMatch(a));
 
         var explicitOptions = new HashSet<string>();
         for (int i = 0; i < cliArgs.Length; i++)

--- a/BBDown/Infrastructure/BBDownMuxer.cs
+++ b/BBDown/Infrastructure/BBDownMuxer.cs
@@ -2,6 +2,7 @@ using System;
 using BBDown.Core.Util;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using static BBDown.Core.Entity.Entity;
@@ -143,7 +144,9 @@ static partial class BBDownMuxer
             // 元数据全部拼进单个 "-itags tool=..." 参数（mp4box 的 itags 语法要求）
             var metaArg = new StringBuilder("tool=");
             if (!string.IsNullOrEmpty(pic))
-                metaArg.Append($":cover=\"{pic}\"");
+                // cover 值与其他 itags 值同规则走 EscapeString：Windows 路径天然含 \，
+                // 不转义会被 mp4box 当转义序列消费，杜比视界自动切 mp4box 时封面静默丢失
+                metaArg.Append($":cover=\"{EscapeString(pic)}\"");
             if (!string.IsNullOrEmpty(episodeId))
                 metaArg.Append($":album=\"{title}\":title=\"{episodeId}\"");
             else
@@ -372,7 +375,10 @@ static partial class BBDownMuxer
             if (pubTime != 0)
             {
                 args.Add("-metadata");
-                args.Add($"creation_time={DateTimeOffset.FromUnixTimeSeconds(pubTime):yyyy-MM-ddTHH:mm:ss.ffffffZ}");
+                // RFC 3339 时间戳喂给机器可读协议：自定义格式的 ":" 是 culture 时间分隔符
+                // 占位符，fi-FI 等区域设置下会产出 "19.30.00" 之类非 ISO-8601 串，
+                // ffmpeg av_parse_time 解析失败后发布时间元数据静默丢失。
+                args.Add($"creation_time={DateTimeOffset.FromUnixTimeSeconds(pubTime).ToString("yyyy-MM-ddTHH:mm:ss.ffffffZ", CultureInfo.InvariantCulture)}");
             }
         }
         args.Add("-c:v");

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 本文件遵循 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/) 规范，版本号遵循 [Semantic Versioning](https://semver.org/lang/zh-CN/)。
 
+## [未发布]
+
+### 修复
+
+- **特定区域设置下视频发布时间元数据丢失**：ffmpeg `creation_time` 时间戳的自定义格式未固定文化，`:` 在 fi-FI 等区域设置下被解析为时间分隔符占位符（产出形如 `19.30.00` 的非 ISO-8601 串），`av_parse_time` 解析失败后元数据静默丢失。现追加 `CultureInfo.InvariantCulture`。
+- **杜比视界自动切 mp4box 时封面静默丢失**：`-itags` 的 `cover` 值（本地封面路径）未按 mp4box itags 值转义规则处理，Windows 路径中的 `\` 被当转义序列消费。现与同函数其它 itags 值一致走 `EscapeString`。
+- **配置文件 URL 被 URL 形值的命令行选项误压制**：`BBDown.config` 中写了下载 URL、命令行又恰好携带值形似 URL 的选项（如 `--aria2c-proxy http://127.0.0.1:7890`、`--work-dir av123`）时，配置里的 URL 被误判"命令行已给出"而丢弃，Spectre 报缺少必填参数。现仅对位置参数应用 URL 启发式（选项值不再参与判定）。
+
+### 安全性
+
+- **Widevine 许可证请求禁跟随重定向**：许可证 POST 的请求体是设备私钥签名的 challenge，原 `VerifiedAppHttpClient`（允许自动重定向）会在 307/308 上连同 body 重放到跨主机目标。新增 `VerifiedNoRedirectClient`（始终校验证书 + 禁自动重定向，独立连接池不受 `--insecure` 降级），3xx 显式报错不跟随（与 gRPC POST 的凭据收口同构）。
+
+### 测试增强
+
+- 全库测试 640 例（新增 6 例）：VerifiedNoRedirectClient 身份稳定性、GET/POST 307 不跟随（含自动跳转客户端对照）、配置合并 URL 形值选项回归与位置参数提取器语义。
+
 ## [1.6.16] - 2026-08-19
 
 ### 修复

--- a/docs/REVIEW_FINDINGS.md
+++ b/docs/REVIEW_FINDINGS.md
@@ -11,10 +11,10 @@
 | RF-1 | 分片扩展名判定一致性（`IsVideoClipPath`） | Low | 采纳（1 行修复） | ✅ 已修复（本轮） |
 | RF-2 | CLI 命令层 Async-over-Sync 迁移 `AsyncCommand` | Medium（对应 REVIEW_PLAN I8） | 技术债，一次性批量重构 | ⏳ 待排期 |
 | RF-3 | serve 已完成任务历史"无界堆积" | —（建议前提不成立） | 不实施（现有防护已覆盖） | ⭕ 维持现状 |
-| RF-4 | Widevine 许可证请求跟随重定向 | Low（一致性） | 改进提议 | ⏳ 待议 |
-| RF-5 | ffmpeg `creation_time` 元数据格式文化敏感 | Low | 一行修复（InvariantCulture） | ⏳ 待议 |
-| RF-6 | mp4box `-itags` cover 值未走 EscapeString | Low（一致性） | 一行修复（补 EscapeString） | ⏳ 待议 |
-| RF-7 | 配置合并 cliHasUrl 把选项值误判为 URL | Low | 启发式收紧（仅扫描位置参数） | ⏳ 待议 |
+| RF-4 | Widevine 许可证请求跟随重定向 | Low（一致性） | 改进提议 | ✅ 已修复（第 9 轮） |
+| RF-5 | ffmpeg `creation_time` 元数据格式文化敏感 | Low | 一行修复（InvariantCulture） | ✅ 已修复（第 9 轮） |
+| RF-6 | mp4box `-itags` cover 值未走 EscapeString | Low（一致性） | 一行修复（补 EscapeString） | ✅ 已修复（第 9 轮） |
+| RF-7 | 配置合并 cliHasUrl 把选项值误判为 URL | Low | 启发式收紧（仅扫描位置参数） | ✅ 已修复（第 9 轮） |
 
 ---
 
@@ -62,7 +62,7 @@
 - **发现**：携带设备签名 `challenge` 的许可证 POST 会随 3xx 重放 body；与本轮 B3-F2"凭据载荷禁跟随重定向"原则（gRPC POST 已改用 `NoRedirectClient` 显式拦 3xx）不一致。
 - **定性**：预存问题（非本批引入）；实际可利用性极低 —— 恒校验 TLS 排除 MITM、`LicenseUrl` 为硬编码可信端点、服务器若被攻破可直接伪造响应无需重定向（无增量攻击面）。
 - **结论**：为原则一致性建议改为禁重定向客户端并显式处理 3xx（与 gRPC POST 同构收口）。副作用极小，可随任意后续安全批次一并落地。
-- **状态**：⏳ 待议（Low，一致性改进，不影响当前发版）。
+- **状态**：✅ 已修复（2026-08-29，第 9 轮）：新增 `HTTPUtil.VerifiedNoRedirectClient`（始终校验证书 + `AllowAutoRedirect=false`，独立池不受 `--insecure` 降级），`WidevineCdm.SendRequestAsync` 切换并在 3xx 显式拦截报错（状态码 <500 不满足重试谓词，按确定性失败立即抛出）。新增 `VerifiedNoRedirectClientTests` 3 例：身份稳定性（不随 SkipSslCheck 路由）、GET 307 不跟随（对照自动跳转客户端跟随）、POST+body 307 不重放。
 
 ---
 
@@ -73,7 +73,7 @@
 - **定性**：预存问题（上游继承）；影响面窄（仅 `--sub-only` 之外的正常混流且区域设置特殊的用户），仅元数据丢失不损坏流。
 - **核实排他性**：全库扫描其余 `yyyy-MM-dd HH:mm` 用法均为日志/控制台展示或文件名场景，文化敏感可接受（或无分隔符安全）；仅此一处喂给机器可读协议。
 - **结论**：一行修复——格式化追加 `CultureInfo.InvariantCulture`（与 277b138 批次的"文化不变解析"原则同构收口）。
-- **状态**：⏳ 待议（Low，可随任意后续低风险批次一并落地）。
+- **状态**：✅ 已修复（2026-08-29，第 9 轮）：`DateTimeOffset.FromUnixTimeSeconds(pubTime).ToString("yyyy-MM-ddTHH:mm:ss.ffffffZ", CultureInfo.InvariantCulture)`，全库唯一喂给机器可读协议的时间戳收口。
 
 ---
 
@@ -83,7 +83,7 @@
 - **发现**：`MuxByMp4box` 顶部对 desc/title/episodeId/author/lang 统一 `EscapeString`（依据其注释：mp4box itags 值内 `"` 与 `\` 必须转义），但同为 itags 值的 `pic`（封面图本地路径）未转义。Windows 路径天然含 `\`（如 `C:\Users\...\cover.jpg`），按代码自述规则会被 mp4box 当转义序列消费，杜比视界自动切 mp4box 的场景下封面可能静默丢失。
 - **定性**：预存问题（上游继承）；mp4box 对裸 `\` 的实际容忍度未实测（GPAC 解析器可能宽松），故定 Low/一致性而非确认缺陷。
 - **结论**：为与同函数其它 itags 值的转义规则保持一致，补 `EscapeString(pic)` 即可（`EscapeString` 对正常路径无副作用——仅翻倍 `\` 与 `"`）。
-- **状态**：⏳ 待议（Low，一致性收口）。
+- **状态**：✅ 已修复（2026-08-29，第 9 轮）：`metaArg.Append($":cover=\"{EscapeString(pic)}\"")`，与同函数顶部 desc/title/episodeId/author/lang 的转义规则一致。
 
 ---
 
@@ -93,7 +93,7 @@
 - **发现**：判定"命令行是否已显式给出 URL"时扫描**全部** argv（含选项的值）。误报场景：URL 写在 `BBDown.config` 中、命令行携带值形似 URL 的选项（如 `--aria2c-proxy http://127.0.0.1:7890`、`--work-dir av123`）→ `cliHasUrl` 误判为 true → 配置文件里的 URL 位置参数被丢弃 → Spectre 报缺少必填参数，用户难以定位。
 - **定性**：预存启发式的精度问题；触发需要"URL 在配置文件 + 命令行恰好有 URL 形值选项"的组合，真实概率低。
 - **结论**：收紧方向——只对"首个非选项 token"（Spectre 位置参数的位置）应用 UrlLikeToken，或先按 aliasMap 跳过带值选项再扫描（`IsSubCommandInvocation` 已有同构跳过逻辑可复用）。改动属行为微调，建议带回归用例（CLI 传 `--aria2c-proxy http://...` + 配置含 URL）单独落地。
-- **状态**：⏳ 待议（Low，启发式收紧，需配测试）。
+- **状态**：✅ 已修复（2026-08-29，第 9 轮）：新增 `GetPositionalTokens`（与 `IsSubCommandInvocation` 同构：带值选项吞下一 token、bool 开关与 `--opt=value` 不吞），`cliHasUrl` 只对位置参数应用 UrlLikeToken。`ConfigMergeTests` 新增 3 例回归：`--aria2c-proxy` URL 形值/`--work-dir` av123 形值不再压制配置文件 URL（配置 URL 与选项值均正确合并）、位置参数提取器跳值语义。
 
 ---
 

--- a/docs/REVIEW_PLAN.md
+++ b/docs/REVIEW_PLAN.md
@@ -150,6 +150,19 @@
 | 批次一护栏代码审查 | ✅ FakeBilibiliApiServer（锁/Dispose/404 快速失败）、ParserFixtureTests（G8 卫生约定、15 用例断言真实消费节点）、Parser.cs `WithApiScheme` 开缝（默认配置行为逐字节不变）均无缺陷 |
 | 新一轮深查 | SubUtil / DanmakuUtil / BBDownMuxer / ExternalProcessRunner / BBDownConfigParser / Program.cs：无 High/Medium；实证排除两个疑点（SubUtil:278 三字符 `\\/` 替换正确匹配 intl 双重转义；JSON 序列化 6 个 source-gen 上下文全覆盖无 AOT 缺口）；产出 3 个 Low（RF-5 culture 时间格式、RF-6 mp4box cover 转义一致性、RF-7 cliHasUrl 误报） |
 
+## 第 9 轮：消纳挂起发现 RF-4/RF-5/RF-6/RF-7（2026-08-29）
+
+> 将 REVIEW_FINDINGS.md 中四个 ⏳ 待议的 Low 级发现一次性落地（分支 `fix/review-r9-pending-findings`）。剩余挂起仅 RF-2（AsyncCommand 批量迁移，技术债待排期）；RF-3 经评估维持现状。
+
+| 项 | 处理 |
+|----|------|
+| RF-5 | ✅ `BBDownMuxer` ffmpeg `creation_time` 格式化追加 `CultureInfo.InvariantCulture`（自定义格式的 `:` 是 culture 时间分隔符占位符，fi-FI 等区域设置下产出非 ISO-8601 串，`av_parse_time` 解析失败后发布时间元数据静默丢失） |
+| RF-6 | ✅ `MuxByMp4box` itags `cover` 值补 `EscapeString(pic)`（Windows 路径天然含 `\`，与同函数其它 itags 值的转义规则对齐，杜比视界自动切 mp4box 时封面不再静默丢失） |
+| RF-4 | ✅ 新增 `HTTPUtil.VerifiedNoRedirectClient`（始终校验证书 + `AllowAutoRedirect=false`，独立池不受 `--insecure` 降级）；`WidevineCdm` 许可证 POST 切换并在 3xx 显式拦截（与 gRPC POST B3-F2 收口同构，签名 challenge 不随 307/308 重放外发） |
+| RF-7 | ✅ `BBDownConfigParser` 新增 `GetPositionalTokens`（与 `IsSubCommandInvocation` 同构跳值），`cliHasUrl` 只对位置参数应用 URL 启发式——`--aria2c-proxy http://...`、`--work-dir av123` 等 URL 形值选项不再压制配置文件里的 URL |
+| 测试 | ✅ 新增 6 例（总计 640）：VerifiedNoRedirectClient 身份稳定/GET 307 不跟随（含自动跳转对照）/POST+body 307 不重放；ConfigMerge 两个 URL 形值选项回归 + 位置参数提取器语义 |
+| 基线 | ✅ dotnet build Release 0 警告 0 错误；单测 640/640 全绿（PR gate 过滤器）；dotnet format --verify-no-changes 通过 |
+
 ---
 
 ## 已完成批次（git log 13766b0..2ab54d1，2026-08）


### PR DESCRIPTION
## 概述

第 9 轮审查迭代：将 REVIEW_FINDINGS.md 中四个 ⏳ 待议的 Low 级发现一次性落地（均已在 R8 评估定级并给出修复方向，本轮按既定方向实施）。

## 变更

### RF-5 — creation_time 文化固定（fix(muxer)）
ffmpeg `creation_time` 自定义格式的 `:` 是 culture 时间分隔符占位符，fi-FI 等区域设置下产出 `19.30.00` 形态的非 ISO-8601 串，`av_parse_time` 解析失败后发布时间元数据静默丢失。格式化追加 `CultureInfo.InvariantCulture`（全库唯一喂给机器可读协议的时间戳收口）。

### RF-6 — mp4box cover 转义一致（fix(muxer)）
`MuxByMp4box` itags 的 `cover` 值（本地封面路径）未走 `EscapeString`，Windows 路径天然含 `\` 被当转义序列消费，杜比视界自动切 mp4box 时封面静默丢失。补 `EscapeString(pic)` 与同函数其它 itags 值对齐。

### RF-4 — Widevine 许可证禁重定向（fix(drm)）
许可证 POST 的请求体是设备私钥签名的 challenge，`VerifiedAppHttpClient`（AllowAutoRedirect=true）会在 307/308 上连同 body 重放到跨主机目标。新增 `HTTPUtil.VerifiedNoRedirectClient`（始终校验证书 + 禁自动重定向，独立池不受 `--insecure` 降级），3xx 显式报错不跟随（与 gRPC POST B3-F2 收口同构）。

### RF-7 — cliHasUrl 启发式收紧（fix(config)）
旧实现对全部 argv 扫描 `UrlLikeToken`，`--aria2c-proxy http://...`、`--work-dir av123` 等 URL 形值选项把"URL 在配置文件 + 命令行有形值选项"误判成"命令行已给出 URL"，配置文件里的 URL 被丢弃。新增 `GetPositionalTokens`（与 `IsSubCommandInvocation` 同构跳值），只对位置参数应用 URL 启发式。

## 测试

- 新增 6 例（634 → 640）：VerifiedNoRedirectClient 身份稳定性 / GET 307 不跟随（含自动跳转对照）/ POST+body 307 不重放；ConfigMerge 两个 URL 形值选项回归 + 位置参数提取器语义
- ✅ `dotnet build BBDown.sln -c Release` 0 警告 0 错误
- ✅ 单测 640/640 全绿（PR gate 过滤器）
- ✅ `dotnet format --verify-no-changes` 通过

## 文档

- REVIEW_PLAN.md：第 9 轮记录
- REVIEW_FINDINGS.md：RF-4/5/6/7 状态结转 ✅ 已修复（剩余挂起仅 RF-2 技术债；RF-3 维持现状）
- CHANGELOG.md：[未发布] 三条修复 + 一条安全性 + 测试增强