### PR TITLE
refactor(cli): RF-2 一次性批量迁移 AsyncCommand

### DIFF
--- a/BBDown.Tests/ServeApiHttpTests.cs
+++ b/BBDown.Tests/ServeApiHttpTests.cs
@@ -58,7 +58,8 @@ public class ServeApiHttpTests
             _taskFile = taskFilePath ?? Path.Combine(Path.GetTempPath(), $"bbdown-tasks-{Guid.NewGuid():N}.json");
             Server = new BBDownApiServer(maxConcurrent: maxConcurrent, serveToken: withToken ? "test-token" : null, taskFilePath: _taskFile);
             Server.SetupServer();
-            _runTask = Task.Run(() => Server.Run(BaseUrl, _cts.Token));
+            // RunAsync 迁移（RF-2）后本身就是异步任务，无需再 Task.Run 包一层
+            _runTask = Server.RunAsync(BaseUrl, _cts.Token);
             // 等待服务器就绪（Kestrel 开始监听）后再发请求：WebApplication 启动在
             // CI 首次运行/慢环境下明显慢于本地，若不等待，所有请求都会撞上
             // Connection refused（{BaseUrl}）竞态。
@@ -363,26 +364,15 @@ public class ServeApiHttpTests
     {
         // 默认安全边界：非回环监听（0.0.0.0/具体网卡 IP）会把端点暴露到局域网/公网，
         // 未配置 --serve-token 时必须拒绝启动——删掉这条防线测试仍全绿。
+        // RunAsync 是 async 方法，校验异常进入返回的 Task；同步前置校验独立在
+        // ValidateListenUrl（RunAsync 启动前也调用它兜底），这里直接断言校验语义。
         var server = new BBDownApiServer();
         server.SetupServer();
-        Assert.Throws<InvalidOperationException>(() => server.Run("http://0.0.0.0:12345"));
-        Assert.Throws<InvalidOperationException>(() => server.Run("http://192.168.1.10:12345"));
-        // 回环监听不带 token 是受信任本地边界，保持兼容（不抛）——但 Run 会阻塞，
-        // 这里用回环地址 + 预取消 token 验证启动路径可进入（不抛非法配置异常）
-        var cts = new CancellationTokenSource();
-        cts.Cancel();
-        try
-        {
-            server.Run("http://127.0.0.1:58699", cts.Token);
-        }
-        catch (InvalidOperationException)
-        {
-            Assert.Fail("回环监听不带 token 不应被拒");
-        }
-        catch (OperationCanceledException)
-        {
-            // 预取消：RunAsync 立即退出，符合预期
-        }
+        Assert.Throws<InvalidOperationException>(() => server.ValidateListenUrl("http://0.0.0.0:12345"));
+        Assert.Throws<InvalidOperationException>(() => server.ValidateListenUrl("http://192.168.1.10:12345"));
+        // 回环监听不带 token 是受信任本地边界，保持兼容（不抛）。
+        // 实际启动路径由上方各 RunningServer 用例覆盖（真实 Kestrel 回环监听）。
+        server.ValidateListenUrl($"http://127.0.0.1:{TestPort.Allocate()}");
     }
 
     [Fact]

--- a/BBDown/Commands/ArticleCommand.cs
+++ b/BBDown/Commands/ArticleCommand.cs
@@ -24,47 +24,43 @@ public class ArticleSettings : CommandSettings
 }
 
 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
-public class ArticleCommand : Command<ArticleSettings>
+public class ArticleCommand : AsyncCommand<ArticleSettings>
 {
-    protected override int Execute(CommandContext context, ArticleSettings settings, CancellationToken cancellationToken)
+    protected override async Task<int> ExecuteAsync(CommandContext context, ArticleSettings settings, CancellationToken cancellationToken)
     {
-        // Task.Run avoids deadlock if called from a thread with a SynchronizationContext
-        return Task.Run(async () =>
+        try
         {
-            try
+            string cvId = ArticleUtil.ExtractCvId(settings.CvId);
+            Logger.Log($"正在获取专栏 cv{cvId}...");
+            var article = await ArticleUtil.FetchAsync(cvId, cancellationToken);
+            // 专栏默认输出目录尊重 --work-dir（与主下载命令一致）。
+            // 相对 --output 同样相对 --work-dir 解析（Path.Combine 对已根化第二参数
+            // 直接透传，绝对路径不受影响）；workDir 为空串时保持 CWD 语义。
+            // 用纯函数 ResolveWorkDir：仅解析/建目录，不切进程 CWD（无全局副作用）。
+            string workDir = Program.ResolveWorkDir(settings.WorkDir);
+            string path = settings.Output is null
+                ? Path.Combine(workDir, $"{LiveStreamUtil.SanitizeFileName(article.Title)}.md")
+                : Path.Combine(workDir, settings.Output);
+            await ArticleUtil.SaveAsMarkdownAsync(article, path);
+            Logger.Log($"专栏已保存: {path}");
+            return 0;
+        }
+        catch (OperationCanceledException ex)
+        {
+            // 区分主动取消（Ctrl+C，token 已取消）与 HttpClient 超时（token 未取消）：
+            // 超时是真实失败，返回非零退出码而非以"已取消"+0 隐藏失败
+            if (cancellationToken.IsCancellationRequested)
             {
-                string cvId = ArticleUtil.ExtractCvId(settings.CvId);
-                Logger.Log($"正在获取专栏 cv{cvId}...");
-                var article = await ArticleUtil.FetchAsync(cvId, cancellationToken);
-                // 专栏默认输出目录尊重 --work-dir（与主下载命令一致）。
-                // 相对 --output 同样相对 --work-dir 解析（Path.Combine 对已根化第二参数
-                // 直接透传，绝对路径不受影响）；workDir 为空串时保持 CWD 语义。
-                // 用纯函数 ResolveWorkDir：仅解析/建目录，不切进程 CWD（无全局副作用）。
-                string workDir = Program.ResolveWorkDir(settings.WorkDir);
-                string path = settings.Output is null
-                    ? Path.Combine(workDir, $"{LiveStreamUtil.SanitizeFileName(article.Title)}.md")
-                    : Path.Combine(workDir, settings.Output);
-                await ArticleUtil.SaveAsMarkdownAsync(article, path);
-                Logger.Log($"专栏已保存: {path}");
+                Logger.LogWarn("已取消");
                 return 0;
             }
-            catch (OperationCanceledException ex)
-            {
-                // 区分主动取消（Ctrl+C，token 已取消）与 HttpClient 超时（token 未取消）：
-                // 超时是真实失败，返回非零退出码而非以"已取消"+0 隐藏失败
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    Logger.LogWarn("已取消");
-                    return 0;
-                }
-                Logger.LogError($"专栏获取超时或被中断: {ex.Message}");
-                return 1;
-            }
-            catch (Exception ex)
-            {
-                Logger.LogError($"专栏获取失败: {ex.Message}");
-                return 1;
-            }
-        }).GetAwaiter().GetResult();
+            Logger.LogError($"专栏获取超时或被中断: {ex.Message}");
+            return 1;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError($"专栏获取失败: {ex.Message}");
+            return 1;
+        }
     }
 }

--- a/BBDown/Commands/LiveCommand.cs
+++ b/BBDown/Commands/LiveCommand.cs
@@ -32,87 +32,83 @@ public class LiveSettings : CommandSettings
 }
 
 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
-public class LiveCommand : Command<LiveSettings>
+public class LiveCommand : AsyncCommand<LiveSettings>
 {
-    protected override int Execute(CommandContext context, LiveSettings settings, CancellationToken cancellationToken)
+    protected override async Task<int> ExecuteAsync(CommandContext context, LiveSettings settings, CancellationToken cancellationToken)
     {
-        // Task.Run avoids deadlock if called from a thread with a SynchronizationContext
-        return Task.Run(async () =>
+        try
         {
-            try
+            // 解析 ffmpeg：录制结束后的分段合成依赖 ffmpeg。直播命令不走主下载的
+            // SetUpWork/FindBinaries 流程，这里显式探测——若 PATH/当前目录均无
+            // ffmpeg，合成阶段会失败且只在收尾时暴露；提前报错让用户尽快安装。
+            if (string.IsNullOrEmpty(BBDownMuxer.FFMPEG) || !File.Exists(BBDownMuxer.FFMPEG))
             {
-                // 解析 ffmpeg：录制结束后的分段合成依赖 ffmpeg。直播命令不走主下载的
-                // SetUpWork/FindBinaries 流程，这里显式探测——若 PATH/当前目录均无
-                // ffmpeg，合成阶段会失败且只在收尾时暴露；提前报错让用户尽快安装。
-                if (string.IsNullOrEmpty(BBDownMuxer.FFMPEG) || !File.Exists(BBDownMuxer.FFMPEG))
-                {
-                    var binPath = ExternalToolHelper.FindExecutable("ffmpeg");
-                    if (string.IsNullOrEmpty(binPath))
-                        throw new FileNotFoundException(
-                            "找不到可执行的ffmpeg文件，直播分段合成需要 ffmpeg。请安装 ffmpeg 并确保其已加入 PATH 后重试。");
-                    BBDownMuxer.FFMPEG = binPath;
-                }
-
-                // 加载登录凭据（--cookie 显式传入优先，否则读取本地 BBDown.data）：
-                // 直播画质接口 getRoomPlayInfo 对未登录请求只返回游客画质（最高 720P），
-                // 带 Cookie 才返回账号可看的最高画质（原画/杜比/4K 按账号权限）。
-                // 此前 live 命令不加载凭据，已登录用户也只能录到 720P。
-                var myOption = new MyOption { Cookie = settings.Cookie, AccessToken = settings.AccessToken };
-                AppSettings? session = await Program.InitializeRequestSessionAsync(myOption, cancellationToken);
-                if (session is not null) Config.Apply(session);
-
-                Logger.Log($"正在解析直播间 {settings.RoomId}...");
-                var info = await LiveStreamUtil.ResolveAsync(settings.RoomId, cancellationToken);
-                Logger.Log($"直播间: {info.Title} (UP: {info.Uname})，画质: {LiveStreamUtil.QualityName(info.Quality)} (qn={info.Quality})");
-                // 直播录制默认输出目录尊重 --work-dir（与主下载命令一致）。
-                // 相对 --output 同样相对 --work-dir 解析（Path.Combine 对已根化第二参数
-                // 直接透传，绝对路径不受影响）；workDir 为空串时保持 CWD 语义。
-                // 用纯函数 ResolveWorkDir：仅解析/建目录，不切进程 CWD（无全局副作用），
-                // .segs 分段目录随输出路径派生，也同步落 workDir。
-                string workDir = Program.ResolveWorkDir(settings.WorkDir);
-                string path = settings.Output is null
-                    ? Path.Combine(workDir, $"{LiveStreamUtil.SanitizeFileName(info.Title)}_直播录制_{DateTime.Now:yyyyMMdd_HHmmss}.flv")
-                    : Path.Combine(workDir, settings.Output);
-                Logger.Log($"开始录制直播流: {path} (Ctrl+C 停止；断流/网络中断自动重连续录)");
-
-                DateTime lastLog = DateTime.MinValue;
-                // 传 roomId：断流/地址过期/网络中断时内部重新解析流地址续录
-                var recordResult = await LiveStreamUtil.DownloadToFileAsync(settings.RoomId, path, total =>
-                {
-                    if (DateTime.Now - lastLog >= TimeSpan.FromSeconds(5))
-                    {
-                        lastLog = DateTime.Now;
-                        Logger.Log($"已录制: {BBDownUtil.FormatFileSize(total)}");
-                    }
-                }, cancellationToken);
-
-                if (recordResult == LiveStreamUtil.LiveRecordResult.NoData)
-                {
-                    // 未收到任何字节就结束：不生成空文件，也不报告"录制已保存"
-                    Logger.LogWarn("录制未收到任何数据，未保存文件");
-                    return 1;
-                }
-                else if (recordResult == LiveStreamUtil.LiveRecordResult.ConcatFailedWithSegmentsSaved)
-                {
-                    Logger.LogError("录制分段已保留，但未能自动合成最终文件。可手动使用 ffmpeg 进行 concat 合并。");
-                    return 1;
-                }
-                Logger.Log($"录制已保存: {path}");
-                return 0;
+                var binPath = ExternalToolHelper.FindExecutable("ffmpeg");
+                if (string.IsNullOrEmpty(binPath))
+                    throw new FileNotFoundException(
+                        "找不到可执行的ffmpeg文件，直播分段合成需要 ffmpeg。请安装 ffmpeg 并确保其已加入 PATH 后重试。");
+                BBDownMuxer.FFMPEG = binPath;
             }
-            // 仅真正的用户取消返回 0；HttpClient 超时/重连耗尽抛出的
-            // TaskCanceledException（token 未取消）必须落到下方失败分支返回 1，
-            // 否则录制实际失败却以成功码退出，脚本/CI 拿不到失败信号。
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+
+            // 加载登录凭据（--cookie 显式传入优先，否则读取本地 BBDown.data）：
+            // 直播画质接口 getRoomPlayInfo 对未登录请求只返回游客画质（最高 720P），
+            // 带 Cookie 才返回账号可看的最高画质（原画/杜比/4K 按账号权限）。
+            // 此前 live 命令不加载凭据，已登录用户也只能录到 720P。
+            var myOption = new MyOption { Cookie = settings.Cookie, AccessToken = settings.AccessToken };
+            AppSettings? session = await Program.InitializeRequestSessionAsync(myOption, cancellationToken);
+            if (session is not null) Config.Apply(session);
+
+            Logger.Log($"正在解析直播间 {settings.RoomId}...");
+            var info = await LiveStreamUtil.ResolveAsync(settings.RoomId, cancellationToken);
+            Logger.Log($"直播间: {info.Title} (UP: {info.Uname})，画质: {LiveStreamUtil.QualityName(info.Quality)} (qn={info.Quality})");
+            // 直播录制默认输出目录尊重 --work-dir（与主下载命令一致）。
+            // 相对 --output 同样相对 --work-dir 解析（Path.Combine 对已根化第二参数
+            // 直接透传，绝对路径不受影响）；workDir 为空串时保持 CWD 语义。
+            // 用纯函数 ResolveWorkDir：仅解析/建目录，不切进程 CWD（无全局副作用），
+            // .segs 分段目录随输出路径派生，也同步落 workDir。
+            string workDir = Program.ResolveWorkDir(settings.WorkDir);
+            string path = settings.Output is null
+                ? Path.Combine(workDir, $"{LiveStreamUtil.SanitizeFileName(info.Title)}_直播录制_{DateTime.Now:yyyyMMdd_HHmmss}.flv")
+                : Path.Combine(workDir, settings.Output);
+            Logger.Log($"开始录制直播流: {path} (Ctrl+C 停止；断流/网络中断自动重连续录)");
+
+            DateTime lastLog = DateTime.MinValue;
+            // 传 roomId：断流/地址过期/网络中断时内部重新解析流地址续录
+            var recordResult = await LiveStreamUtil.DownloadToFileAsync(settings.RoomId, path, total =>
             {
-                Logger.LogWarn("录制已取消");
-                return 0;
-            }
-            catch (Exception ex)
+                if (DateTime.Now - lastLog >= TimeSpan.FromSeconds(5))
+                {
+                    lastLog = DateTime.Now;
+                    Logger.Log($"已录制: {BBDownUtil.FormatFileSize(total)}");
+                }
+            }, cancellationToken);
+
+            if (recordResult == LiveStreamUtil.LiveRecordResult.NoData)
             {
-                Logger.LogError($"直播录制失败: {ex.Message}");
+                // 未收到任何字节就结束：不生成空文件，也不报告"录制已保存"
+                Logger.LogWarn("录制未收到任何数据，未保存文件");
                 return 1;
             }
-        }).GetAwaiter().GetResult();
+            else if (recordResult == LiveStreamUtil.LiveRecordResult.ConcatFailedWithSegmentsSaved)
+            {
+                Logger.LogError("录制分段已保留，但未能自动合成最终文件。可手动使用 ffmpeg 进行 concat 合并。");
+                return 1;
+            }
+            Logger.Log($"录制已保存: {path}");
+            return 0;
+        }
+        // 仅真正的用户取消返回 0；HttpClient 超时/重连耗尽抛出的
+        // TaskCanceledException（token 未取消）必须落到下方失败分支返回 1，
+        // 否则录制实际失败却以成功码退出，脚本/CI 拿不到失败信号。
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            Logger.LogWarn("录制已取消");
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError($"直播录制失败: {ex.Message}");
+            return 1;
+        }
     }
 }

--- a/BBDown/Commands/LoginCommand.cs
+++ b/BBDown/Commands/LoginCommand.cs
@@ -10,14 +10,13 @@ public class LoginSettings : CommandSettings
 }
 
 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
-public class LoginCommand : Command<LoginSettings>
+public class LoginCommand : AsyncCommand<LoginSettings>
 {
-    protected override int Execute(CommandContext context, LoginSettings settings, CancellationToken cancellationToken)
+    protected override async Task<int> ExecuteAsync(CommandContext context, LoginSettings settings, CancellationToken cancellationToken)
     {
         try
         {
-            // Task.Run avoids deadlock if called from a thread with a SynchronizationContext
-            return Task.Run(() => BBDownLoginUtil.LoginWEB(cancellationToken)).GetAwaiter().GetResult() ? 0 : 1;
+            return await BBDownLoginUtil.LoginWEB(cancellationToken) ? 0 : 1;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {

--- a/BBDown/Commands/LoginTVCommand.cs
+++ b/BBDown/Commands/LoginTVCommand.cs
@@ -5,14 +5,13 @@ using System.Threading;
 namespace BBDown.Commands;
 
 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
-public class LoginTVCommand : Command<LoginSettings>
+public class LoginTVCommand : AsyncCommand<LoginSettings>
 {
-    protected override int Execute(CommandContext context, LoginSettings settings, CancellationToken cancellationToken)
+    protected override async Task<int> ExecuteAsync(CommandContext context, LoginSettings settings, CancellationToken cancellationToken)
     {
         try
         {
-            // Task.Run avoids deadlock if called from a thread with a SynchronizationContext
-            return Task.Run(() => BBDownLoginUtil.LoginTV(cancellationToken)).GetAwaiter().GetResult() ? 0 : 1;
+            return await BBDownLoginUtil.LoginTV(cancellationToken) ? 0 : 1;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {

--- a/BBDown/Commands/ServeCommand.cs
+++ b/BBDown/Commands/ServeCommand.cs
@@ -32,9 +32,9 @@ public class ServeSettings : CommandSettings
 }
 
 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
-public class ServeCommand : Command<ServeSettings>
+public class ServeCommand : AsyncCommand<ServeSettings>
 {
-    protected override int Execute(CommandContext context, ServeSettings settings, CancellationToken cancellationToken)
+    protected override async Task<int> ExecuteAsync(CommandContext context, ServeSettings settings, CancellationToken cancellationToken)
     {
         _ = BBDownUtil.CheckUpdateAsync(cancellationToken);
         try
@@ -50,7 +50,7 @@ public class ServeCommand : Command<ServeSettings>
             var serveToken = ResolveServeToken(settings.ServeToken, Environment.GetEnvironmentVariable("BBDOWN_SERVE_TOKEN"));
             // 默认安全边界的前置校验：非回环监听（0.0.0.0 / :: / 具体网卡 IP）会把任务
             // 端点暴露到局域网/公网，必须显式配置 --serve-token 才能启动。
-            // 这里给出可读错误；BBDownApiServer.Run 内还有兜底防御（InvalidOperationException）。
+            // 这里给出可读错误；BBDownApiServer.RunAsync 内还有兜底防御（InvalidOperationException）。
             if (!IsLoopbackListenUrl(settings.ListenUrl) && string.IsNullOrEmpty(serveToken))
             {
                 Logger.LogError(
@@ -58,7 +58,7 @@ public class ServeCommand : Command<ServeSettings>
                     $"非回环监听必须配置 --serve-token 才能启动，否则任意客户端都能提交任务并访问本机文件。");
                 return 1;
             }
-            Program.StartServer(settings.ListenUrl, settings.MaxConcurrent, serveToken, settings.NotifyWebhook, cancellationToken, settings.TrustedProxy);
+            await Program.StartServerAsync(settings.ListenUrl, settings.MaxConcurrent, serveToken, settings.NotifyWebhook, cancellationToken, settings.TrustedProxy);
             return 0;
         }
         catch (OperationCanceledException)

--- a/BBDown/Commands/SubCommand.cs
+++ b/BBDown/Commands/SubCommand.cs
@@ -116,109 +116,105 @@ public class SubRemoveCommand : Command<SubRemoveSettings>
 }
 
 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
-public class SubCheckCommand : Command<SubCheckSettings>
+public class SubCheckCommand : AsyncCommand<SubCheckSettings>
 {
-    protected override int Execute(CommandContext context, SubCheckSettings settings, CancellationToken cancellationToken)
+    protected override async Task<int> ExecuteAsync(CommandContext context, SubCheckSettings settings, CancellationToken cancellationToken)
     {
-        // Task.Run avoids deadlock if called from a thread with a SynchronizationContext。
         // 批量检查期间 Ctrl+C 会取消当前下载；直接退出进程则等效于整体取消。
-        return Task.Run(async () =>
+        var subs = SubscriptionStore.Load();
+        if (subs.Count == 0)
         {
-            var subs = SubscriptionStore.Load();
-            if (subs.Count == 0)
-            {
-                Logger.LogWarn("当前没有订阅，请先用 BBDown sub add <目标> 添加");
-                return 0;
-            }
-
-            // 订阅解析与拉取（VIP/登录态内容）需要凭据：
-            // LoadCredentials 会优先应用命令行 --cookie/--access-token，否则加载本地 BBDown.data。
-            // 此前只处理显式传参，已登录但未传参时枚举阶段以匿名身份执行，VIP/区域订阅会被误判为空。
-            var sessionOption = new MyOption
-            {
-                Cookie = settings.Cookie,
-                AccessToken = settings.AccessToken,
-                UseTvApi = settings.UseTvApi,
-                UseAppApi = settings.UseAppApi,
-                UseIntlApi = settings.UseIntlApi,
-            };
-            // 统一初始化请求会话：订阅枚举（mid: 空间/收藏夹/合集等）经 SpaceVideoFetcher →
-            // Parser.WbiSign 签名，必须先取得 wbi，否则空 wbi 的 w_rid 会被 B 站拒绝。
-            // 返回的完整会话（含本地凭据与新 wbi）在父流程（SubCheck 自身异步流）内显式应用——
-            // 子方法内 AsyncLocal 写入不会回流，只应用 newWbi 会让本地凭据丢失。
-            var session = await Program.InitializeRequestSessionAsync(sessionOption, cancellationToken);
-            if (session is not null) Core.Config.Apply(session);
-
-            int failedSubs = 0;
-            foreach (var sub in subs)
-            {
-                Logger.Log($"检查订阅: {sub.Name} ({sub.Target})");
-                try
-                {
-                    string resolved = await UrlResolver.ResolveAsync(sub.Target, cancellationToken);
-                    if (string.IsNullOrEmpty(resolved)) continue;
-
-                    var fetcher = FetcherFactory.CreateFetcher(resolved, settings.UseIntlApi);
-                    var vInfo = await fetcher.FetchAsync(resolved, cancellationToken);
-
-                    var allAids = vInfo.PagesInfo.Select(p => p.aid).Where(a => !string.IsNullOrEmpty(a)).Distinct().ToList();
-                    var history = SubscriptionStore.LoadHistory(sub.Target);
-                    var newAids = allAids.Where(a => !history.Contains(a)).ToList();
-
-                    if (newAids.Count == 0)
-                    {
-                        Logger.Log("  没有新增内容");
-                        continue;
-                    }
-
-                    Logger.Log($"  发现 {newAids.Count} 个新内容: av{string.Join(", av", newAids)}");
-                    bool anyAidFailed = false;
-                    foreach (var aid in newAids)
-                    {
-                        try
-                        {
-                            var opt = BuildOption($"av{aid}", settings);
-                            await Program.DoWorkAsync(opt, cancellationToken);
-                            SubscriptionStore.RecordDownloaded(sub.Target, aid);
-                        }
-                        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-                        {
-                            throw;
-                        }
-                        catch (Exception ex) when (ex is HttpRequestException or JsonException or KeyNotFoundException
-                                                    or InvalidOperationException or IOException or ArgumentException
-                                                    or TimeoutException or TaskCanceledException)
-                        {
-                            anyAidFailed = true;
-                            Logger.LogWarn($"  av{aid} 下载失败（继续下一个）: {ex.Message}");
-                        }
-                    }
-                    if (anyAidFailed) failedSubs++;
-                }
-                catch (SubscriptionDataCorruptException)
-                {
-                    // 订阅持久化数据损坏（历史/清单损坏）：必须终止整个 sub check，不能按
-                    // 普通单订阅失败继续——否则后续订阅会因历史文件已不存在而把全部内容
-                    // 当作新增重新下载，并覆盖一份不完整的历史。
-                    throw;
-                }
-                catch (Exception ex) when (ex is HttpRequestException or JsonException or KeyNotFoundException
-                                            or InvalidOperationException or IOException or ArgumentException
-                                            or TimeoutException or TaskCanceledException)
-                {
-                    // 单个订阅失败不中止其余订阅，但必须计入失败数：
-                    // 全部失败仍返回 0 会让脚本/CI 无法区分"全部成功"与"全部失败"
-                    failedSubs++;
-                    Logger.LogWarn($"  订阅检查失败: {ex.Message}");
-                }
-            }
-            if (failedSubs > 0)
-            {
-                Logger.LogWarn($"订阅检查完成，{failedSubs} 个订阅失败");
-                return 1;
-            }
+            Logger.LogWarn("当前没有订阅，请先用 BBDown sub add <目标> 添加");
             return 0;
-        }).GetAwaiter().GetResult();
+        }
+
+        // 订阅解析与拉取（VIP/登录态内容）需要凭据：
+        // LoadCredentials 会优先应用命令行 --cookie/--access-token，否则加载本地 BBDown.data。
+        // 此前只处理显式传参，已登录但未传参时枚举阶段以匿名身份执行，VIP/区域订阅会被误判为空。
+        var sessionOption = new MyOption
+        {
+            Cookie = settings.Cookie,
+            AccessToken = settings.AccessToken,
+            UseTvApi = settings.UseTvApi,
+            UseAppApi = settings.UseAppApi,
+            UseIntlApi = settings.UseIntlApi,
+        };
+        // 统一初始化请求会话：订阅枚举（mid: 空间/收藏夹/合集等）经 SpaceVideoFetcher →
+        // Parser.WbiSign 签名，必须先取得 wbi，否则空 wbi 的 w_rid 会被 B 站拒绝。
+        // 返回的完整会话（含本地凭据与新 wbi）在父流程（SubCheck 自身异步流）内显式应用——
+        // 子方法内 AsyncLocal 写入不会回流，只应用 newWbi 会让本地凭据丢失。
+        var session = await Program.InitializeRequestSessionAsync(sessionOption, cancellationToken);
+        if (session is not null) Core.Config.Apply(session);
+
+        int failedSubs = 0;
+        foreach (var sub in subs)
+        {
+            Logger.Log($"检查订阅: {sub.Name} ({sub.Target})");
+            try
+            {
+                string resolved = await UrlResolver.ResolveAsync(sub.Target, cancellationToken);
+                if (string.IsNullOrEmpty(resolved)) continue;
+
+                var fetcher = FetcherFactory.CreateFetcher(resolved, settings.UseIntlApi);
+                var vInfo = await fetcher.FetchAsync(resolved, cancellationToken);
+
+                var allAids = vInfo.PagesInfo.Select(p => p.aid).Where(a => !string.IsNullOrEmpty(a)).Distinct().ToList();
+                var history = SubscriptionStore.LoadHistory(sub.Target);
+                var newAids = allAids.Where(a => !history.Contains(a)).ToList();
+
+                if (newAids.Count == 0)
+                {
+                    Logger.Log("  没有新增内容");
+                    continue;
+                }
+
+                Logger.Log($"  发现 {newAids.Count} 个新内容: av{string.Join(", av", newAids)}");
+                bool anyAidFailed = false;
+                foreach (var aid in newAids)
+                {
+                    try
+                    {
+                        var opt = BuildOption($"av{aid}", settings);
+                        await Program.DoWorkAsync(opt, cancellationToken);
+                        SubscriptionStore.RecordDownloaded(sub.Target, aid);
+                    }
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                    {
+                        throw;
+                    }
+                    catch (Exception ex) when (ex is HttpRequestException or JsonException or KeyNotFoundException
+                                                or InvalidOperationException or IOException or ArgumentException
+                                                or TimeoutException or TaskCanceledException)
+                    {
+                        anyAidFailed = true;
+                        Logger.LogWarn($"  av{aid} 下载失败（继续下一个）: {ex.Message}");
+                    }
+                }
+                if (anyAidFailed) failedSubs++;
+            }
+            catch (SubscriptionDataCorruptException)
+            {
+                // 订阅持久化数据损坏（历史/清单损坏）：必须终止整个 sub check，不能按
+                // 普通单订阅失败继续——否则后续订阅会因历史文件已不存在而把全部内容
+                // 当作新增重新下载，并覆盖一份不完整的历史。
+                throw;
+            }
+            catch (Exception ex) when (ex is HttpRequestException or JsonException or KeyNotFoundException
+                                        or InvalidOperationException or IOException or ArgumentException
+                                        or TimeoutException or TaskCanceledException)
+            {
+                // 单个订阅失败不中止其余订阅，但必须计入失败数：
+                // 全部失败仍返回 0 会让脚本/CI 无法区分"全部成功"与"全部失败"
+                failedSubs++;
+                Logger.LogWarn($"  订阅检查失败: {ex.Message}");
+            }
+        }
+        if (failedSubs > 0)
+        {
+            Logger.LogWarn($"订阅检查完成，{failedSubs} 个订阅失败");
+            return 1;
+        }
+        return 0;
     }
 
     private static MyOption BuildOption(string url, SubCheckSettings s) => new()

--- a/BBDown/Commands/WatchLaterCommand.cs
+++ b/BBDown/Commands/WatchLaterCommand.cs
@@ -50,79 +50,75 @@ public class WatchLaterSettings : CommandSettings
 }
 
 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
-public class WatchLaterCommand : Command<WatchLaterSettings>
+public class WatchLaterCommand : AsyncCommand<WatchLaterSettings>
 {
-    protected override int Execute(CommandContext context, WatchLaterSettings settings, CancellationToken cancellationToken)
+    protected override async Task<int> ExecuteAsync(CommandContext context, WatchLaterSettings settings, CancellationToken cancellationToken)
     {
-        // Task.Run avoids deadlock if called from a thread with a SynchronizationContext
-        return Task.Run(async () =>
+        try
         {
-            try
-            {
-                // 稍后再看接口需要登录：先加载本地登录凭据（或用户传入的 cookie）。
-                // 用统一会话初始化入口：不仅加载凭据，还做登录检查并提取 wbi——
-                // 稍后再看列表与后续下载都用 WEB API，空 wbi 的 w_rid 会被 B 站拒绝。
-                // 返回的完整会话在父流程自身异步流内应用（子方法内 AsyncLocal 写入不回流）。
-                var bootstrap = new MyOption { Cookie = settings.Cookie, AccessToken = settings.AccessToken, UseTvApi = settings.UseTvApi, UseAppApi = settings.UseAppApi, UseIntlApi = settings.UseIntlApi };
-                var session = await Program.InitializeRequestSessionAsync(bootstrap, cancellationToken);
-                if (session is not null) Core.Config.Apply(session);
+            // 稍后再看接口需要登录：先加载本地登录凭据（或用户传入的 cookie）。
+            // 用统一会话初始化入口：不仅加载凭据，还做登录检查并提取 wbi——
+            // 稍后再看列表与后续下载都用 WEB API，空 wbi 的 w_rid 会被 B 站拒绝。
+            // 返回的完整会话在父流程自身异步流内应用（子方法内 AsyncLocal 写入不回流）。
+            var bootstrap = new MyOption { Cookie = settings.Cookie, AccessToken = settings.AccessToken, UseTvApi = settings.UseTvApi, UseAppApi = settings.UseAppApi, UseIntlApi = settings.UseIntlApi };
+            var session = await Program.InitializeRequestSessionAsync(bootstrap, cancellationToken);
+            if (session is not null) Core.Config.Apply(session);
 
-                Logger.Log("正在获取稍后再看列表...");
-                var list = await FetchWatchLaterAsync(cancellationToken);
-                if (list.Count == 0)
-                {
-                    Logger.Log("稍后再看列表为空");
-                    return 0;
-                }
+            Logger.Log("正在获取稍后再看列表...");
+            var list = await FetchWatchLaterAsync(cancellationToken);
+            if (list.Count == 0)
+            {
+                Logger.Log("稍后再看列表为空");
+                return 0;
+            }
 
-                var targets = settings.Limit > 0 ? list.Take(settings.Limit).ToList() : list;
-                Logger.Log($"共 {list.Count} 个稍后再看，开始下载 {targets.Count} 个...");
-                int succeeded = 0;
-                int failed = 0;
-                foreach (var (aid, title) in targets)
-                {
-                    Logger.Log($"--- 下载 av{aid} {title} ---");
-                    try
-                    {
-                        var opt = BuildOption($"av{aid}", settings);
-                        await Program.DoWorkAsync(opt, cancellationToken);
-                        succeeded++;
-                    }
-                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-                    {
-                        throw;
-                    }
-                    catch (Exception ex) when (ex is HttpRequestException or JsonException or InvalidOperationException
-                                                or IOException or ArgumentException or TimeoutException or TaskCanceledException)
-                    {
-                        // 单个视频失败不应中止整批稍后再看，但必须计入失败数，
-                        // 让调用方拿到非零退出码（此前静默继续并返回 0，
-                        // 脚本/CI 无法区分"全部成功"与"部分失败"）
-                        failed++;
-                        Logger.LogWarn($"av{aid} 下载失败（继续下一个）: {ex.Message}");
-                    }
-                }
-                Logger.Log($"稍后再看下载完成：成功 {succeeded} 个，失败 {failed} 个");
-                return failed == 0 ? 0 : 1;
-            }
-            catch (OperationCanceledException ex)
+            var targets = settings.Limit > 0 ? list.Take(settings.Limit).ToList() : list;
+            Logger.Log($"共 {list.Count} 个稍后再看，开始下载 {targets.Count} 个...");
+            int succeeded = 0;
+            int failed = 0;
+            foreach (var (aid, title) in targets)
             {
-                // 区分主动取消（Ctrl+C，token 已取消）与 HttpClient 超时（token 未取消）：
-                // 超时是真实失败，必须返回非零退出码，不能以"已取消"+0 隐藏失败（脚本/CI 误判成功）
-                if (cancellationToken.IsCancellationRequested)
+                Logger.Log($"--- 下载 av{aid} {title} ---");
+                try
                 {
-                    Logger.LogWarn("已取消");
-                    return 0;
+                    var opt = BuildOption($"av{aid}", settings);
+                    await Program.DoWorkAsync(opt, cancellationToken);
+                    succeeded++;
                 }
-                Logger.LogError($"稍后再看下载超时或被中断: {ex.Message}");
-                return 1;
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception ex) when (ex is HttpRequestException or JsonException or InvalidOperationException
+                                            or IOException or ArgumentException or TimeoutException or TaskCanceledException)
+                {
+                    // 单个视频失败不应中止整批稍后再看，但必须计入失败数，
+                    // 让调用方拿到非零退出码（此前静默继续并返回 0，
+                    // 脚本/CI 无法区分"全部成功"与"部分失败"）
+                    failed++;
+                    Logger.LogWarn($"av{aid} 下载失败（继续下一个）: {ex.Message}");
+                }
             }
-            catch (Exception ex)
+            Logger.Log($"稍后再看下载完成：成功 {succeeded} 个，失败 {failed} 个");
+            return failed == 0 ? 0 : 1;
+        }
+        catch (OperationCanceledException ex)
+        {
+            // 区分主动取消（Ctrl+C，token 已取消）与 HttpClient 超时（token 未取消）：
+            // 超时是真实失败，必须返回非零退出码，不能以"已取消"+0 隐藏失败（脚本/CI 误判成功）
+            if (cancellationToken.IsCancellationRequested)
             {
-                Logger.LogError($"稍后再看下载失败: {ex.Message}");
-                return 1;
+                Logger.LogWarn("已取消");
+                return 0;
             }
-        }).GetAwaiter().GetResult();
+            Logger.LogError($"稍后再看下载超时或被中断: {ex.Message}");
+            return 1;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError($"稍后再看下载失败: {ex.Message}");
+            return 1;
+        }
     }
 
     private static async Task<List<(string Aid, string Title)>> FetchWatchLaterAsync(CancellationToken token)

--- a/BBDown/Infrastructure/BBDownApiServer.cs
+++ b/BBDown/Infrastructure/BBDownApiServer.cs
@@ -363,7 +363,13 @@ public partial class BBDownApiServer
         });
     }
 
-    public void Run(string url, CancellationToken cancellationToken = default)
+    /// <summary>
+    /// 监听地址前置校验（同步）：URL 合法性与"非回环必须带 token"安全边界。
+    /// 独立成同步方法：RunAsync 是 async 方法，校验异常会进入返回的 Task 而非
+    /// 同步抛出，测试无法用 Assert.Throws 语义直接断言；ServeCommand 的同步
+    /// 预检失败路径也依赖同步异常。RunAsync 启动前仍调用本方法兜底。
+    /// </summary>
+    public void ValidateListenUrl(string url)
     {
         if (app is null) return;
         bool result = Uri.TryCreate(url, UriKind.Absolute, out Uri? uriResult)
@@ -385,10 +391,18 @@ public partial class BBDownApiServer
             throw new InvalidOperationException(
                 $"监听地址 {url} 不是回环地址（0.0.0.0 / :: / 具体网卡 IP 等），必须配置 --serve-token 才能启动，否则任意客户端都能提交任务并访问本机文件。");
         }
+    }
+
+    public async Task RunAsync(string url, CancellationToken cancellationToken = default)
+    {
+        ValidateListenUrl(url);
+        if (app is null) return;
         app.Urls.Add(url);
         try
         {
-            Task.Run(() => app.RunAsync(cancellationToken)).GetAwaiter().GetResult();
+            // RF-2：命令层已迁移 AsyncCommand，serve 全程 await——不再用
+            // Task.Run + GetAwaiter().GetResult() 让一个线程池线程阻塞整个服务生命周期。
+            await app.RunAsync(cancellationToken);
         }
         catch (OperationCanceledException)
         {
@@ -399,6 +413,9 @@ public partial class BBDownApiServer
         // "取消 → 终止外部进程 → 持久化"，避免退出进程时遗留孤儿 ffmpeg/aria2c
         // 或丢失未落盘的任务记录。等待超时（例如下载器在取消后仍卡在外部进程上）
         // 则放弃等待，不无限阻塞退出。
+        // Task.WaitAll 是有界同步等待且仅发生在进程退出路径（≤30s），与 RF-2 消除的
+        // "整个服务生命周期占线程阻塞"不同，保留同步形式以避免 WhenAll+WaitAsync
+        // 的异常类型变化（TimeoutException/首个业务异常）改变退出语义。
         Task[] inflight;
         lock (_inFlightLock) { inflight = [.. _inFlightTasks]; }
         if (inflight.Length > 0)

--- a/BBDown/Program.cs
+++ b/BBDown/Program.cs
@@ -217,7 +217,7 @@ partial class Program
         }).ToArray();
     }
 
-    internal static void StartServer(string? listenUrl, int maxConcurrent = 3, string? serveToken = null, string? notifyWebhook = null, CancellationToken cancellationToken = default, bool trustProxy = false)
+    internal static async Task StartServerAsync(string? listenUrl, int maxConcurrent = 3, string? serveToken = null, string? notifyWebhook = null, CancellationToken cancellationToken = default, bool trustProxy = false)
     {
         var defaultListenUrl = "http://127.0.0.1:23333";
         // serve 为长驻进程：标记模式，此后各任务的 --work-dir 不再写进程 CWD
@@ -227,11 +227,11 @@ partial class Program
         server.SetupServer();
         try
         {
-            server.Run(string.IsNullOrEmpty(listenUrl) ? defaultListenUrl : listenUrl, cancellationToken);
+            await server.RunAsync(string.IsNullOrEmpty(listenUrl) ? defaultListenUrl : listenUrl, cancellationToken);
         }
         finally
         {
-            // 关停后释放持久日志 writer 的文件句柄（Run 可能抛异常，finally 保证释放）
+            // 关停后释放持久日志 writer 的文件句柄（RunAsync 可能抛异常，finally 保证释放）
             Logger.CloseFile();
         }
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - **杜比视界自动切 mp4box 时封面静默丢失**：`-itags` 的 `cover` 值（本地封面路径）未按 mp4box itags 值转义规则处理，Windows 路径中的 `\` 被当转义序列消费。现与同函数其它 itags 值一致走 `EscapeString`。
 - **配置文件 URL 被 URL 形值的命令行选项误压制**：`BBDown.config` 中写了下载 URL、命令行又恰好携带值形似 URL 的选项（如 `--aria2c-proxy http://127.0.0.1:7890`、`--work-dir av123`）时，配置里的 URL 被误判"命令行已给出"而丢弃，Spectre 报缺少必填参数。现仅对位置参数应用 URL 启发式（选项值不再参与判定）。
 
+### 改进
+
+- **CLI 命令层全量迁移 `AsyncCommand`**：`login`/`logintv`/`article`/`live`/`sub check`/`watchlater`/`serve` 7 个命令不再以 `Task.Run + GetAwaiter().GetResult()` 阻塞线程池线程等待异步操作（serve 长驻进程此前整个生命周期额外占用 1 个阻塞线程）；serve 链路改为真异步（`RunAsync`/`StartServerAsync`），监听地址前置校验独立为 `ValidateListenUrl`。各命令退出码与错误语义不变。
+
 ### 安全性
 
 - **Widevine 许可证请求禁跟随重定向**：许可证 POST 的请求体是设备私钥签名的 challenge，原 `VerifiedAppHttpClient`（允许自动重定向）会在 307/308 上连同 body 重放到跨主机目标。新增 `VerifiedNoRedirectClient`（始终校验证书 + 禁自动重定向，独立连接池不受 `--insecure` 降级），3xx 显式报错不跟随（与 gRPC POST 的凭据收口同构）。

--- a/docs/REVIEW_FINDINGS.md
+++ b/docs/REVIEW_FINDINGS.md
@@ -9,7 +9,7 @@
 | 编号 | 主题 | 评估级别 | 判定 | 状态 |
 |------|------|---------|------|------|
 | RF-1 | 分片扩展名判定一致性（`IsVideoClipPath`） | Low | 采纳（1 行修复） | ✅ 已修复（本轮） |
-| RF-2 | CLI 命令层 Async-over-Sync 迁移 `AsyncCommand` | Medium（对应 REVIEW_PLAN I8） | 技术债，一次性批量重构 | ⏳ 待排期 |
+| RF-2 | CLI 命令层 Async-over-Sync 迁移 `AsyncCommand` | Medium（对应 REVIEW_PLAN I8） | 技术债，一次性批量重构 | ✅ 已修复（第 10 轮） |
 | RF-3 | serve 已完成任务历史"无界堆积" | —（建议前提不成立） | 不实施（现有防护已覆盖） | ⭕ 维持现状 |
 | RF-4 | Widevine 许可证请求跟随重定向 | Low（一致性） | 改进提议 | ✅ 已修复（第 9 轮） |
 | RF-5 | ffmpeg `creation_time` 元数据格式文化敏感 | Low | 一行修复（InvariantCulture） | ✅ 已修复（第 9 轮） |
@@ -38,7 +38,12 @@
   - **死锁面不存在**：BBDown 为纯控制台进程，无 `SynchronizationContext`，`GetResult()` 无死锁条件。
   - **饥饿面极低**：CLI 单次执行，每命令生命周期仅额外占用 1 个线程池线程；唯一长驻点是 serve 的 `StartServer`（serve 全程占 1 线程），线程池可伸缩无实际危害；serve 的并发请求处理本身为 async，不经过此路径。
 - **结论**：方向正确（Spectre 官方推荐写法、占用更少线程），但定性应降为"高质量重构"而非隐患；建议作为**一次性批量重构**（8 命令 + 注册 + 保持 ExitCode 语义），不零散进行；不列入当前发版。
-- **状态**：⏳ 待排期（技术债，REVIEW_PLAN I8）。
+- **状态**：✅ 已修复（2026-08-29，第 10 轮，一次性批量落地）：
+  - 迁移 **7** 个命令至 `AsyncCommand<TSettings>`（Login/LoginTV/Article/Live/SubCheck/WatchLater/Serve）。原清单列 8 处，核实 `DefaultCommand` 已是 `AsyncCommand`（清单漂移修正，实际迁移面 7 处）。
+  - serve 链路：`BBDownApiServer.Run` 拆为同步前置校验 `ValidateListenUrl`（测试可用 `Assert.Throws` 同步断言、ServeCommand 快速失败路径保留同步异常语义）+ 真异步 `RunAsync`（`await app.RunAsync`，不再 `Task.Run` + `GetResult()` 让一个线程池线程阻塞整个服务生命周期）；`Program.StartServer` → `StartServerAsync`。关停段的 30s `Task.WaitAll` 有界同步等待**保留**：仅发生在进程退出路径，与生命周期阻塞不同，且避免 `WhenAll`+`WaitAsync` 改变超时/异常类型语义（代码注释说明）。
+  - 各命令原有 catch/退出码语义**逐字保留**（cancel→0、超时→1、批量失败计数→1）。原建议中的 `ExitCodeFor` 评估后**不抽取**：四个命令的取消/超时/部分失败分支消息与过滤条件各不相同，强行共享 helper 会掩盖差异。
+  - 计划外残留：`ExternalToolHelper` 一处 `GetAwaiter().GetResult()` 为短进程探针的 stdout/stderr 同步读取，非命令生命周期阻塞，维持现状。
+  - 测试适配：`ServeApiHttpTests.RunningServer` 直用 `RunAsync`（去 `Task.Run` 包装）；`NonLoopbackListen_WithoutToken_Throws` 改断言 `ValidateListenUrl` 同步异常语义（真实回环启动路径由各 RunningServer 用例继续覆盖）。
 
 ---
 

--- a/docs/REVIEW_PLAN.md
+++ b/docs/REVIEW_PLAN.md
@@ -163,6 +163,16 @@
 | 测试 | ✅ 新增 6 例（总计 640）：VerifiedNoRedirectClient 身份稳定/GET 307 不跟随（含自动跳转对照）/POST+body 307 不重放；ConfigMerge 两个 URL 形值选项回归 + 位置参数提取器语义 |
 | 基线 | ✅ dotnet build Release 0 警告 0 错误；单测 640/640 全绿（PR gate 过滤器）；dotnet format --verify-no-changes 通过 |
 
+## 第 10 轮：RF-2 一次性批量重构（AsyncCommand 迁移，2026-08-29）
+
+> 消纳 REVIEW_FINDINGS 最后一个 ⏳ 挂起项 RF-2（分支 `refactor/rf2-async-command-migration`）。至此 FINDINGS 全部条目结转完毕（其余为"已修复"或"维持现状"）。
+
+| 项 | 处理 |
+|----|------|
+| RF-2 | ✅ 7 个命令迁移 `AsyncCommand<TSettings>`（Login/LoginTV/Article/Live/SubCheck/WatchLater/Serve；原清单含 DefaultCommand，核实已迁移过，漂移修正）；serve 链路 `Run` → `ValidateListenUrl` + `RunAsync`、`StartServer` → `StartServerAsync`，serve 全程 await 不再占用线程池线程阻塞等待；各命令 catch/退出码语义逐字保留，`ExitCodeFor` 评估后不抽取（各命令取消/超时/部分失败语义不同，见 FINDINGS RF-2） |
+| 测试 | ✅ ServeApiHttpTests 适配：RunningServer 直用 `RunAsync`、NonLoopbackListen 改断 `ValidateListenUrl` 同步异常语义；单测 640/640 全绿（PR gate 过滤器）+ LocalIntegration 3/3 |
+| 基线 | ✅ dotnet build Release 0 警告 0 错误；dotnet format --verify-no-changes 通过；serve 冒烟：`--help` 退出码 0、serve 监听回环、`/get-tasks/running` 200 |
+
 ---
 
 ## 已完成批次（git log 13766b0..2ab54d1，2026-08）


### PR DESCRIPTION
## 概述

第 10 轮审查迭代：消纳 REVIEW_FINDINGS 最后一个 ⏳ 挂起项 **RF-2**（对应 REVIEW_PLAN I8）。RF-2 已明确登记为"一次性批量重构，不零散进行"，本轮按既定结论整批落地。至此 FINDINGS 全部条目结转完毕。

## 变更

### 命令迁移（7 处）
`login`/`logintv`/`article`/`live`/`sub check`/`watchlater`/`serve` 从 `Command<T>` + `Task.Run(...).GetAwaiter().GetResult()` 迁移到 `AsyncCommand<T>`（`ExecuteAsync`）。原清单列 8 处，核实 `DefaultCommand` 已是 `AsyncCommand`（清单漂移修正）。各命令 catch/退出码语义**逐字保留**（cancel→0、超时→1、批量失败计数→1）；原建议的 `ExitCodeFor` 评估后不抽取——各命令的取消/超时/部分失败分支语义不同，强行共享 helper 会掩盖差异（详见 FINDINGS）。

### serve 链路真异步化
- `BBDownApiServer.Run` 拆为 **同步前置校验 `ValidateListenUrl`**（测试可用 `Assert.Throws` 断言、ServeCommand 快速失败保留同步异常）+ **`RunAsync`**（`await app.RunAsync`）——不再 `Task.Run + GetResult()` 让一个线程池线程阻塞整个服务生命周期
- `Program.StartServer` → `StartServerAsync`
- 关停段 30s `Task.WaitAll` 有界同步等待**保留**：仅进程退出路径触发（与生命周期阻塞不同），且避免 `WhenAll`+`WaitAsync` 改变超时/异常类型语义（注释说明）

### 测试适配
- `ServeApiHttpTests.RunningServer` 直用 `RunAsync`（去 `Task.Run` 包装）
- `NonLoopbackListen_WithoutToken_Throws` 改断言 `ValidateListenUrl` 同步异常语义；真实回环启动路径由各 `RunningServer` 用例继续覆盖

## 验证

- ✅ `dotnet build BBDown.sln -c Release` 0 警告 0 错误
- ✅ 单测 640/640 全绿（PR gate 过滤器）+ LocalIntegration 3/3
- ✅ `dotnet format --verify-no-changes` 通过
- ✅ serve 冒烟：`--help` 退出码 0；serve 监听回环、`/get-tasks/running` 返回 200

## 文档

- REVIEW_PLAN.md：第 10 轮记录
- REVIEW_FINDINGS.md：RF-2 结转 ✅（附 ExitCodeFor 不抽取理由与清单漂移修正）
- CHANGELOG.md：[未发布] 改进条目