### PR TITLE
fix: RF-8~RF-13 全库审查新发现修复与安全性加固

### DIFF
--- a/BBDown.Core/Parser.cs
+++ b/BBDown.Core/Parser.cs
@@ -81,14 +81,18 @@ public static partial class Parser
         //Console.WriteLine(api);
         string webJson = await HTTPUtil.GetWebSourceAsync(api, token: token);
         //以下情况从网页源代码尝试解析
-        if (webJson.Contains("\"大会员专享限制\""))
+        if (IsVipRestrictedResponse(webJson))
         {
             Logger.Log("此视频需要大会员，您大概率需要登录一个有大会员的账号才可以下载，尝试从网页源码解析");
             // 该回退只对番剧成立：UGC 的 epId 为空，构造 /bangumi/play/ep<空> 会拿到
             // 无效页面并被 PlayerJsonRegex 误替换成空/垃圾内容，导致后续解析失败
             if (!string.IsNullOrEmpty(epId))
             {
-                string webUrl = "https://www.bilibili.com/bangumi/play/ep" + epId;
+                // 镜像站（BiliPlus 等）场景：番剧接口走 Config.Current.EpHost，回退抓取的
+                // 网页源也应跟随配置的主机，否则镜像站用户会被重定向回官方域名（可能不可达）。
+                // 默认配置 EpHost 即官方 api 主机，直接替换即可；非默认时用配置的镜像主机。
+                string webHost = Config.Current.EpHost == "api.bilibili.com" ? "www.bilibili.com" : Config.Current.EpHost;
+                string webUrl = $"{WithApiScheme(webHost)}/bangumi/play/ep{epId}";
                 string webSource = await HTTPUtil.GetWebSourceAsync(webUrl, token: token, rejectHtml: false);
                 var match = PlayerJsonRegex().Match(webSource);
                 // 页面不含 window.__playinfo__（登录墙/错误页/风控页）时 Groups[1] 为空串，
@@ -99,6 +103,28 @@ public static partial class Parser
             }
         }
         return webJson;
+    }
+
+    /// <summary>
+    /// 判定 playurl API 响应是否为"大会员专享限制"错误。
+    /// 优先解析 JSON 根对象的 message 字段（B 站当前返回
+    /// {"code":-10403,"message":"大会员专享限制",...}）；子串匹配对文案措辞变化
+    /// 脆弱（改文案即失效），仅在响应不是合法 JSON 时作为兜底。
+    /// </summary>
+    internal static bool IsVipRestrictedResponse(string webJson)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(webJson);
+            return doc.RootElement.TryGetProperty("message", out var msg)
+                && msg.ValueKind == JsonValueKind.String
+                && msg.GetString()?.Contains("大会员专享限制") == true;
+        }
+        catch (JsonException)
+        {
+            // 非 JSON 响应（风控 HTML 等）：退回原子串匹配兜底
+            return webJson.Contains("\"大会员专享限制\"");
+        }
     }
 
     private static async Task<string> GetPlayJsonAsync(string aid, string cid, string epId, string qn, string code = "0", CancellationToken token = default)
@@ -722,6 +748,7 @@ public static partial class Parser
 
     [GeneratedRegex("window.__playinfo__=([\\s\\S]*?)<\\/script>")]
     private static partial Regex PlayerJsonRegex();
-    [GeneratedRegex("http.*:\\d+")]
-    private static partial Regex BaseUrlRegex();
+    // internal 供测试直接验证：只匹配主机:端口，query 中的 ":数字" 不得误判为端口
+    [GeneratedRegex("^https?://[^/:]+:\\d+")]
+    internal static partial Regex BaseUrlRegex();
 }

--- a/BBDown.Core/Util/HTTPUtil.cs
+++ b/BBDown.Core/Util/HTTPUtil.cs
@@ -162,6 +162,9 @@ public static partial class HTTPUtil
     private static HttpClient NoRedirectClient =>
         Config.Current.SkipSslCheck ? _insecureNoRedirectClient.Value : _noRedirectClient.Value;
 
+    /// <summary>手动逐跳重定向校验的最大跳数（防开放重定向无限循环）。</summary>
+    private const int MaxRedirectHops = 10;
+
     private static readonly string[] platforms = { "Windows NT 10.0; Win64", "Macintosh; Intel Mac OS X 10_15", "X11; Linux x86_64" };
 
     private static string RandomVersion(int minInclusive, int maxInclusive)
@@ -230,34 +233,53 @@ public static partial class HTTPUtil
         {
             try
             {
-                using var webRequest = new HttpRequestMessage(HttpMethod.Get, url);
-                webRequest.Headers.TryAddWithoutValidation("User-Agent", GetUserAgent(userAgent));
-                webRequest.Headers.TryAddWithoutValidation("Accept-Encoding", "gzip, deflate");
-                if (!string.IsNullOrEmpty(Config.Current.Cookie))
-                    webRequest.Headers.TryAddWithoutValidation("Cookie", Config.Current.Cookie);
-                webRequest.Headers.CacheControl = CacheControlHeaderValue.Parse("no-cache");
-                webRequest.Headers.Connection.Clear();
+                // 重定向逐跳校验：登录轮询携带操作者 Cookie，若自动跟随 3xx，被攻破的
+                // passport 域名或开放重定向可把带凭据的请求与响应 Set-Cookie 凭证引向任意
+                // 主机（B3-S1 纵深防御）。改用禁自动跳转客户端手动逐跳，每一跳的 Location
+                // 在发起下一跳前必须通过 IsTrustedCookieHost，与 GetWebSourceAnonymousCheckedAsync 同构。
+                string current = url;
+                for (int hop = 0; hop < MaxRedirectHops; hop++)
+                {
+                    using var webRequest = new HttpRequestMessage(HttpMethod.Get, current);
+                    webRequest.Headers.TryAddWithoutValidation("User-Agent", GetUserAgent(userAgent));
+                    webRequest.Headers.TryAddWithoutValidation("Accept-Encoding", "gzip, deflate");
+                    if (!string.IsNullOrEmpty(Config.Current.Cookie))
+                        webRequest.Headers.TryAddWithoutValidation("Cookie", Config.Current.Cookie);
+                    webRequest.Headers.CacheControl = CacheControlHeaderValue.Parse("no-cache");
+                    webRequest.Headers.Connection.Clear();
 
-                Logger.LogDebug("获取网页内容: Url: {0}", SensitiveDataMasker.MaskUrl(url));
-                using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(token);
-                timeoutCts.CancelAfter(TimeSpan.FromMilliseconds(Config.Current.ApiTimeoutMs));
-                using var webResponse = await AppHttpClient.SendAsync(webRequest, HttpCompletionOption.ResponseHeadersRead, timeoutCts.Token);
-                // 登录接口同样参与服务器时钟校准（响应头 Date）：与其它 API 调用保持一致，
-                // 否则依赖签名时间戳的后续请求在校准缺失下可能因时钟偏差被拒。
-                // 用 fromVerifiedPool 区分：--insecure 连接的 Date 头由中间人可控，不写全局偏移
-                CalibrateClock(webResponse, fromVerifiedPool: !Config.Current.SkipSslCheck);
-                // 5xx 显式抛错走下方退避；4xx 交给 EnsureSuccessStatusCode 立即抛出（不重试）
-                if (!webResponse.IsSuccessStatusCode && (int)webResponse.StatusCode >= 500)
-                    throw new HttpRequestException($"服务器返回 {(int)webResponse.StatusCode} {webResponse.ReasonPhrase}", null, webResponse.StatusCode);
-                webResponse.EnsureSuccessStatusCode();
+                    Logger.LogDebug("获取网页内容: Url: {0}", SensitiveDataMasker.MaskUrl(current));
+                    using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(token);
+                    timeoutCts.CancelAfter(TimeSpan.FromMilliseconds(Config.Current.ApiTimeoutMs));
+                    using var webResponse = await NoRedirectClient.SendAsync(webRequest, HttpCompletionOption.ResponseHeadersRead, timeoutCts.Token);
+                    // 登录接口同样参与服务器时钟校准（响应头 Date）：与其它 API 调用保持一致，
+                    // 否则依赖签名时间戳的后续请求在校准缺失下可能因时钟偏差被拒。
+                    // 用 fromVerifiedPool 区分：--insecure 连接的 Date 头由中间人可控，不写全局偏移
+                    CalibrateClock(webResponse, fromVerifiedPool: !Config.Current.SkipSslCheck);
+                    if ((int)webResponse.StatusCode is >= 300 and < 400)
+                    {
+                        var location = webResponse.Headers.Location;
+                        if (location is null) break;
+                        var next = location.IsAbsoluteUri ? location : new Uri(new Uri(current), location);
+                        if (!IsTrustedCookieHost(next.ToString()))
+                            throw new InvalidOperationException($"重定向目标未通过可信主机校验: {SensitiveDataMasker.MaskUrl(next.ToString())}");
+                        current = next.ToString();
+                        continue;
+                    }
+                    // 5xx 显式抛错走下方退避；4xx 交给 EnsureSuccessStatusCode 立即抛出（不重试）
+                    if (!webResponse.IsSuccessStatusCode && (int)webResponse.StatusCode >= 500)
+                        throw new HttpRequestException($"服务器返回 {(int)webResponse.StatusCode} {webResponse.ReasonPhrase}", null, webResponse.StatusCode);
+                    webResponse.EnsureSuccessStatusCode();
 
-                string htmlCode = await webResponse.Content.ReadAsStringAsync(timeoutCts.Token);
-                // 截断实参含 `htmlCode[..1024]` 的子串分配：DebugLog 关闭时跳过求值，
-                // 避免为每次元数据响应（可达数 MB）白白分配 1KB 截断串
-                if (Config.Current.DebugLog)
-                    Logger.LogDebug("Response: {0}", htmlCode.Length > 1024 ? htmlCode[..1024] + $"…[截断, 共 {htmlCode.Length} 字符]" : htmlCode);
-                List<string> setCookies = webResponse.Headers.TryGetValues("Set-Cookie", out var vals) ? vals.ToList() : [];
-                return (htmlCode, setCookies);
+                    string htmlCode = await webResponse.Content.ReadAsStringAsync(timeoutCts.Token);
+                    // 截断实参含 `htmlCode[..1024]` 的子串分配：DebugLog 关闭时跳过求值，
+                    // 避免为每次元数据响应（可达数 MB）白白分配 1KB 截断串
+                    if (Config.Current.DebugLog)
+                        Logger.LogDebug("Response: {0}", htmlCode.Length > 1024 ? htmlCode[..1024] + $"…[截断, 共 {htmlCode.Length} 字符]" : htmlCode);
+                    List<string> setCookies = webResponse.Headers.TryGetValues("Set-Cookie", out var vals) ? vals.ToList() : [];
+                    return (htmlCode, setCookies);
+                }
+                throw new HttpRequestException($"重定向跳数超过上限 ({MaxRedirectHops})");
             }
             catch (HttpRequestException ex) when (attempt < maxRetry && (ex.StatusCode is null || (int)ex.StatusCode >= 500))
             {

--- a/BBDown.Tests/DownloadPipelineTests.cs
+++ b/BBDown.Tests/DownloadPipelineTests.cs
@@ -125,6 +125,43 @@ public class DownloadPipelineTests
         => Assert.Equal(expected, Program.ClampRoleAudioIndex(aIndex, count));
 
     [Fact]
+    public void DeleteResidualChapterFiles_RemovesChapterPrefixedFiles()
+    {
+        // RF-11-D1：跳过/失败路径必须按前缀清理章节 meta 文件——muxer 写唯一名
+        // chapters-{basename}（防并发混流互相覆盖），旧清理路径只删固定名 "chapters"，
+        // 导致重跑已下载视频时残留 chapters-* 文件。本方法应按前缀匹配两者都清掉，
+        // 且不能误删同名前缀之外的正常文件。
+        var dir = Path.Combine(Path.GetTempPath(), "bbdown-chapters-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var fixedName = Path.Combine(dir, "chapters");
+            var uniqueName = Path.Combine(dir, "chapters-abc");
+            var otherName = Path.Combine(dir, "subtitle.zh.srt");
+            File.WriteAllText(fixedName, "x");
+            File.WriteAllText(uniqueName, "x");
+            File.WriteAllText(otherName, "x");
+
+            Program.DeleteResidualChapterFiles(dir);
+
+            Assert.False(File.Exists(fixedName), "固定名 chapters 应被清理");
+            Assert.False(File.Exists(uniqueName), "muxer 唯一名 chapters-* 应被清理");
+            Assert.True(File.Exists(otherName), "非 chapters 前缀文件不得误删");
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public void DeleteResidualChapterFiles_MissingOrEmptyDir_DoesNotThrow()
+    {
+        // 目录不存在 / 无匹配文件时静默返回：跳过路径兜底清理不能因 IO 异常掩盖主流程结果
+        Program.DeleteResidualChapterFiles(Path.Combine(Path.GetTempPath(), "bbdown-no-such-" + Guid.NewGuid().ToString("N")));
+    }
+
+    [Fact]
     public async Task MultiThreadDownloadAndMerge_MergesAndCleansClips_UnderLock()
     {
         // 用本地 HTTP 服务提供一段小文件，验证多线程下载在锁内完成"下载→合并→清理"：

--- a/BBDown.Tests/ParserPlayLimitTests.cs
+++ b/BBDown.Tests/ParserPlayLimitTests.cs
@@ -40,4 +40,33 @@ public class ParserPlayLimitTests
         using var doc = JsonDocument.Parse(json);
         Parser.ThrowIfBizError(doc.RootElement); // 不应抛异常
     }
+
+    // ── RF-11-P1：大会员回退判定改 JSON message 字段解析（不再依赖裸子串匹配）──
+
+    [Theory]
+    [InlineData("""{"code":-10403,"message":"大会员专享限制"}""", true)]
+    [InlineData("""{"code":-10403,"message":"大会员专享限制","data":{}}""", true)]
+    [InlineData("""{"code":0,"message":"success","data":{}}""", false)]      // 正常响应
+    [InlineData("""{"code":-10403,"message":"版权受限"}""", false)]           // 其它限制文案不算大会员
+    [InlineData("""{"data":{}}""", false)]                                    // 无 message
+    public void IsVipRestrictedResponse_ReadsJsonMessageField(string json, bool expected)
+        => Assert.Equal(expected, Parser.IsVipRestrictedResponse(json));
+
+    [Theory]
+    [InlineData("""<html>window.__playinfo__="大会员专享限制"</html>""", true)]  // 非 JSON 兜底子串
+    [InlineData("<html>risk-control</html>", false)]                            // 非 JSON 无命中
+    public void IsVipRestrictedResponse_NonJson_FallsBackToSubstring(string body, bool expected)
+        => Assert.Equal(expected, Parser.IsVipRestrictedResponse(body));
+
+    // ── RF-11-P2：BaseUrlRegex 收紧（query 中的 ":数字" 不得误判为端口）──
+
+    [Theory]
+    [InlineData("http://host:8080/path", true)]
+    [InlineData("https://host:443/", true)]
+    [InlineData("http://upos-sz.example.com:8443/a.m4s?b=1", true)]
+    [InlineData("http://host/path?x=1:2", false)]   // query 含 :数字 不误判为端口
+    [InlineData("https://host/path", false)]         // 无端口
+    [InlineData("host:8080/path", false)]            // 缺 scheme
+    public void BaseUrlRegex_MatchesOnlyHostPort(string url, bool expected)
+        => Assert.Equal(expected, Parser.BaseUrlRegex().IsMatch(url));
 }

--- a/BBDown.Tests/RedirectHopValidationTests.cs
+++ b/BBDown.Tests/RedirectHopValidationTests.cs
@@ -1,8 +1,8 @@
 using System.Net;
+using BBDown.Core;
 using BBDown.Core.Util;
 
 namespace BBDown.Tests;
-
 /// <summary>
 /// 逐跳重定向校验测试：验证 <see cref="HTTPUtil.GetWebLocationCheckedAsync"/> 在
 /// 每一跳的 Location 被请求之前就用回调校验，非可信目标会被拦截（不会真正访问）。
@@ -193,6 +193,58 @@ public class RedirectHopValidationTests
             _listener.Close();
             try { _loop.Wait(TimeSpan.FromSeconds(2)); } catch { }
             _cts.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task GetWebSourceWithSetCookiesAsync_UntrustedRedirect_ThrowsBeforeNextHop()
+    {
+        // 登录轮询携带操作者 Cookie（且响应 Set-Cookie 是新凭证下发通道）：若自动跟随
+        // 3xx，被攻破的入口或开放重定向可把带凭据的请求与响应引向任意主机。逐跳校验
+        // 必须在发起下一跳前拦截非可信 Location，绝不访问 evil.com。
+        using var server = new LocalRedirectServer(new()
+        {
+            { "/entry", (302, "http://evil.example.com/final") },
+        });
+        var baseUrl = $"http://127.0.0.1:{server.Port}";
+        var original = Config.Current;
+        try
+        {
+            Config.ApplyToCurrentAsyncFlow(original with { Cookie = "SESSDATA=secret" });
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                HTTPUtil.GetWebSourceWithSetCookiesAsync($"{baseUrl}/entry", token: CancellationToken.None));
+            Assert.Contains("可信主机", ex.Message);
+            // 校验发生在发起下一跳网络请求之前：evil.com 绝不被访问（服务端只收到入口 1 次）
+            Assert.Equal(1, server.RequestCount);
+        }
+        finally
+        {
+            Config.ApplyToCurrentAsyncFlow(original);
+        }
+    }
+
+    [Fact]
+    public async Task GetWebSourceWithSetCookiesAsync_TrustedRedirect_FollowsAndReturnsBody()
+    {
+        // 同一可信主机内的重定向（相对 Location 落在回环服务上）应正常跟随并返回
+        // 终态 body：逐跳校验只拦截非可信目标，不破坏正常登录轮询链路。
+        using var server = new LocalRedirectServer(new()
+        {
+            { "/entry", (302, "/final") },
+        });
+        var baseUrl = $"http://127.0.0.1:{server.Port}";
+        var original = Config.Current;
+        try
+        {
+            Config.ApplyToCurrentAsyncFlow(original with { Cookie = "SESSDATA=secret" });
+            var (body, _) = await HTTPUtil.GetWebSourceWithSetCookiesAsync($"{baseUrl}/entry", token: CancellationToken.None);
+            Assert.NotNull(body);
+            // 入口 1 次 + 跟随 1 次
+            Assert.Equal(2, server.RequestCount);
+        }
+        finally
+        {
+            Config.ApplyToCurrentAsyncFlow(original);
         }
     }
 }

--- a/BBDown.Tests/ServeApiSecurityTests.cs
+++ b/BBDown.Tests/ServeApiSecurityTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Sockets;
+using System.Reflection;
 
 namespace BBDown.Tests;
 
@@ -139,6 +140,69 @@ public class ServeApiSecurityTests
         Assert.True(server.IsAuthLockedOut("10.0.0.1"), "锁死后持续拒绝");
         // 其它来源 IP 不受影响（同机合法客户端/攻击者换 IP 各自独立计数）
         Assert.False(server.IsAuthLockedOut("10.0.0.2"));
+    }
+
+    [Fact]
+    public void IsAuthLockedOut_DictionaryStaysBounded_UnderIpHammering()
+    {
+        // 攻击者持续换新 IP/XFF 轰炸时，每条失败都会登记新键；这些键是"最近失败"
+        // 永不过期，仅删过期条目约束不住字典大小。必须按最后失败时间裁剪，字典有界。
+        var server = new BBDownApiServer();
+        var maxTracked = (int)typeof(BBDownApiServer)
+            .GetField("MaxTrackedAuthFailureIps", BindingFlags.NonPublic | BindingFlags.Static)!
+            .GetValue(null)!;
+
+        // 模拟远超上限的独立来源（1.2 倍于上限），每个来源只失败一次（不触发锁死）
+        for (int i = 0; i < maxTracked * 12 / 10; i++)
+        {
+            server.IsAuthLockedOut($"10.0.{i / 250}.{i % 250}");
+        }
+
+        var dict = (Dictionary<string, List<DateTime>>)typeof(BBDownApiServer)
+            .GetField("_authFailures", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(server)!;
+        // 允许 +1 的窗口抖动（裁剪发生在下次登记前），但绝不能随 IP 数线性增长
+        Assert.InRange(dict.Count, 1, maxTracked + 1);
+    }
+
+    [Fact]
+    public void TrimFinishedTasksLocked_KeepsNewestByCreateTime_NotByCompletionOrder()
+    {
+        // 列表按"完成顺序"追加，与"创建顺序"无关。旧实现按完成顺序 RemoveRange 头部
+        // 会误删"后创建但先完成"的任务；必须按 TaskCreateTime 保留最新的上限条。
+        var server = new BBDownApiServer();
+        var maxFinished = (int)typeof(BBDownApiServer)
+            .GetField("MaxFinishedTasks", BindingFlags.NonPublic | BindingFlags.Static)!
+            .GetValue(null)!;
+
+        var finished = (List<DownloadTask>)typeof(BBDownApiServer)
+            .GetField("finishedTasks", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(server)!;
+
+        long now = DateTimeOffset.Now.ToUnixTimeSeconds();
+        // 构造 上限+5 条：前 5 条"后创建但先完成"（TaskCreateTime 最新、排在列表头），
+        // 其余 上限 条创建时间更旧。旧实现 RemoveRange(0,5) 会删掉头 5 条（最新的，错误）。
+        for (int i = 0; i < 5; i++)
+            finished.Add(new DownloadTask($"new-{i}", "u", now - i));
+        for (int i = 0; i < maxFinished; i++)
+            finished.Add(new DownloadTask($"old-{i}", "u", now - maxFinished - i));
+
+        var method = typeof(BBDownApiServer)
+            .GetMethod("TrimFinishedTasksLocked", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var taskLock = typeof(BBDownApiServer)
+            .GetField("_taskLock", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(server)!;
+        lock (taskLock)
+        {
+            method.Invoke(server, null);
+        }
+
+        Assert.Equal(maxFinished, finished.Count);
+        Assert.Contains(finished, t => t.Aid == "new-0");   // 最新创建的被保留
+        Assert.Contains(finished, t => t.Aid == "new-4");
+        Assert.DoesNotContain(finished, t => t.Aid == $"old-{maxFinished - 5}"); // 最旧创建的被裁剪
+        Assert.DoesNotContain(finished, t => t.Aid == $"old-{maxFinished - 1}");
+        Assert.Contains(finished, t => t.Aid == "old-0"); // 较新的 old 条目保留（不是删列表头）
     }
 
     [Fact]

--- a/BBDown/Application/Download.cs
+++ b/BBDown/Application/Download.cs
@@ -214,6 +214,9 @@ internal partial class Program
             if (!string.IsNullOrEmpty(audioPath) && File.Exists(audioPath)) try { File.Delete(audioPath); } catch { }
             foreach (var s in subtitleInfo) if (File.Exists(s.path)) try { File.Delete(s.path); } catch { }
             foreach (var a in audioMaterial) if (File.Exists(a.path)) try { File.Delete(a.path); } catch { }
+            // 章节 meta 文件同样可能由本次或上次任务残留（见 DeleteResidualChapterFiles），
+            // 跳过路径一并兜底清理，避免重跑已下载视频时 aid 目录残留章节文件。
+            DeleteResidualChapterFiles(PathUtil.ResolveWorkPath(p.aid));
             var aidDir = PathUtil.ResolveWorkPath(p.aid);
             if (Directory.Exists(aidDir) && !Directory.EnumerateFileSystemEntries(aidDir).Any())
             {
@@ -297,8 +300,7 @@ internal partial class Program
             var dir = Path.GetDirectoryName(string.IsNullOrEmpty(videoPath) ? audioPath : videoPath);
             if (dir is not null)
             {
-                try { if (File.Exists(Path.Combine(dir, "chapters"))) File.Delete(Path.Combine(dir, "chapters")); }
-                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException) { }
+                DeleteResidualChapterFiles(dir);
             }
         }
         foreach (var s in subtitleInfo)
@@ -322,6 +324,26 @@ internal partial class Program
             try { if (Directory.GetFiles(aidDir).Length == 0) Directory.Delete(aidDir, true); }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException) { }
         }
+    }
+
+    /// <summary>
+    /// 删除目录下残留的章节 meta 文件。muxer 按输出文件名派生唯一名
+    /// （chapters-{basename}，见 BBDownMuxer，防并发混流互相覆盖），早期版本与
+    /// 部分清理路径用固定名 "chapters"；这里按前缀匹配两者，跳过/失败路径兜底清理。
+    /// 单文件清理失败不影响整体（磁盘占用/句柄异常不该掩盖主流程结果）。
+    /// internal 供测试直接验证前缀匹配清理行为。
+    /// </summary>
+    internal static void DeleteResidualChapterFiles(string dir)
+    {
+        try
+        {
+            foreach (var f in Directory.GetFiles(dir, "chapters*"))
+            {
+                try { File.Delete(f); }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException) { }
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException) { }
     }
 
     private static async Task<bool> DownloadPageAsync(Page p, MyOption myOption, VInfo vInfo, List<Page> selectedPagesInfo, Dictionary<string, byte> encodingPriority, Dictionary<string, int> dfnPriority,
@@ -694,8 +716,7 @@ internal partial class Program
                                 try { if (File.Exists(s.path)) File.Delete(s.path); }
                                 catch (Exception ex) when (ex is IOException or UnauthorizedAccessException) { }
                             }
-                            try { if (File.Exists(Path.Combine(PathUtil.ResolveWorkPath(p.aid), "chapters"))) File.Delete(Path.Combine(PathUtil.ResolveWorkPath(p.aid), "chapters")); }
-                            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException) { }
+                            DeleteResidualChapterFiles(PathUtil.ResolveWorkPath(p.aid));
                             if (Directory.Exists(PathUtil.ResolveWorkPath(p.aid)) && Directory.GetFiles(PathUtil.ResolveWorkPath(p.aid)).Length == 0)
                             {
                                 Directory.Delete(PathUtil.ResolveWorkPath(p.aid), true);
@@ -948,6 +969,18 @@ internal partial class Program
                         {
                             Logger.Log($"{savePath}已存在, 跳过下载...");
                             relatedTask?.AddSavePath(savePath);
+                            // 清理本次已下载但未被消费的装饰性文件（封面/字幕/章节）：与 dash
+                            // 分支的跳过清理行为保持一致。封面下载于轨道提取前，若不清理，
+                            // 每次重跑已下载的视频都会残留封面/字幕/章节文件，且 Directory
+                            // 非空时 aid 目录也删不掉。
+                            try { if (File.Exists(coverPath)) File.Delete(coverPath); }
+                            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException) { }
+                            foreach (var s in subtitleInfo)
+                            {
+                                try { if (File.Exists(s.path)) File.Delete(s.path); }
+                                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException) { }
+                            }
+                            DeleteResidualChapterFiles(PathUtil.ResolveWorkPath(p.aid));
                             // 只清理空目录：目录里的可续传分片可能属于其它分P的上次中断下载
                             // （aid 工作目录按稿件共享），不能因本P跳过而连带删除。
                             if (selectedPagesInfo.Count == 1 && Directory.Exists(PathUtil.ResolveWorkPath(p.aid)) && Directory.GetFiles(PathUtil.ResolveWorkPath(p.aid)).Length == 0)

--- a/BBDown/Infrastructure/BBDownApiServer.cs
+++ b/BBDown/Infrastructure/BBDownApiServer.cs
@@ -503,7 +503,9 @@ public partial class BBDownApiServer
     /// 认证失败限速判定：1 分钟滑动窗口内失败次数达到阈值返回 true（拒绝服务）。
     /// 每次失败都调用本方法登记；限速状态按来源 IP 隔离，同机合法客户端不受影响。
     /// 窗口过期的空条目会被移除，防止攻击者用大量一次性 IP 轰炸时字典无限增长
-    /// （每 IP 一条永不清除的空 list）；字典超过上限时顺带清理全部过期条目。
+    /// （每 IP 一条永不清除的空 list）。攻击者持续用新 IP/XFF 值时每条都是"最近失败"
+    /// 不过期，仅删过期条目约束不住字典大小——字典超过上限时按最后失败时间裁剪，
+    /// 只保留最近活跃的 <see cref="MaxTrackedAuthFailureIps"/> 条。
     /// internal 供测试直接验证滑动窗口阈值。
     /// </summary>
     internal bool IsAuthLockedOut(string clientIp)
@@ -517,6 +519,17 @@ public partial class BBDownApiServer
             {
                 foreach (var stale in _authFailures.Where(kv => kv.Value.Count == 0 || now - kv.Value[^1] > TimeSpan.FromMinutes(1)).ToList())
                     _authFailures.Remove(stale.Key);
+                // 新 IP 持续轰炸时过期清理后仍超上限：按最后失败时间裁剪，保留最近
+                // 活跃的上限条，其余移除，保证字典有界（O(n log n) 仅在异常规模触发）。
+                if (_authFailures.Count > MaxTrackedAuthFailureIps)
+                {
+                    var overflow = _authFailures
+                        .OrderBy(kv => kv.Value[^1]) // 最后失败时间最旧的最先裁剪
+                        .Take(_authFailures.Count - MaxTrackedAuthFailureIps)
+                        .Select(kv => kv.Key)
+                        .ToList();
+                    foreach (var key in overflow) _authFailures.Remove(key);
+                }
             }
             if (!_authFailures.TryGetValue(clientIp, out var list))
             {
@@ -656,6 +669,8 @@ public partial class BBDownApiServer
     /// <summary>
     /// 在 <see cref="_taskLock"/> 持锁前提下，按保留策略截断已完成任务列表：
     /// 超龄记录与超出 <see cref="MaxFinishedTasks"/> 的溢出记录被移除。
+    /// 列表按完成顺序追加，与创建顺序无关——裁剪溢出时必须按创建时间排序，
+    /// 移除最旧创建的，保留最新的（此前直接 RemoveRange 头部会误删"后创建但先完成"的任务）。
     /// </summary>
     private void TrimFinishedTasksLocked()
     {
@@ -666,7 +681,12 @@ public partial class BBDownApiServer
         finishedTasks.RemoveAll(t => t.TaskCreateTime < cutoff);
         if (finishedTasks.Count > MaxFinishedTasks)
         {
-            finishedTasks.RemoveRange(0, finishedTasks.Count - MaxFinishedTasks);
+            // 只移除最旧创建的溢出条目，保留其余任务的原顺序（API 按完成顺序展示）
+            var toRemove = finishedTasks
+                .OrderBy(t => t.TaskCreateTime)
+                .Take(finishedTasks.Count - MaxFinishedTasks)
+                .ToHashSet();
+            finishedTasks.RemoveAll(t => toRemove.Contains(t));
         }
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - **特定区域设置下视频发布时间元数据丢失**：ffmpeg `creation_time` 时间戳的自定义格式未固定文化，`:` 在 fi-FI 等区域设置下被解析为时间分隔符占位符（产出形如 `19.30.00` 的非 ISO-8601 串），`av_parse_time` 解析失败后元数据静默丢失。现追加 `CultureInfo.InvariantCulture`。
 - **杜比视界自动切 mp4box 时封面静默丢失**：`-itags` 的 `cover` 值（本地封面路径）未按 mp4box itags 值转义规则处理，Windows 路径中的 `\` 被当转义序列消费。现与同函数其它 itags 值一致走 `EscapeString`。
 - **配置文件 URL 被 URL 形值的命令行选项误压制**：`BBDown.config` 中写了下载 URL、命令行又恰好携带值形似 URL 的选项（如 `--aria2c-proxy http://127.0.0.1:7890`、`--work-dir av123`）时，配置里的 URL 被误判"命令行已给出"而丢弃，Spectre 报缺少必填参数。现仅对位置参数应用 URL 启发式（选项值不再参与判定）。
+- **FLV 跳过下载路径残留临时元数据文件**：FLV 跳过路径未清理封面、字幕与章节文件，且章节清理此前仅匹配固定名 `chapters` 而未覆盖 muxer 产出的唯一名 `chapters-{basename}`。现与 DASH 分支行为对齐并在跳过/失败路径按 `chapters*` 前缀兜底清理。
+- **serve 已完成任务溢出裁剪按完成顺序误删**：`finishedTasks` 按完成时间追加，旧逻辑直接移除列表头部会误删"后创建但先完成"的任务。现改为按 `TaskCreateTime` 排序裁剪最旧创建的任务。
+- **Parser 大会员回退硬编码域名与子串匹配脆弱**：番剧大会员回退网页源硬编码 `www.bilibili.com`（忽略 `EpHost` 镜像配置）；大会员错误判定依赖裸子串 `\"大会员专享限制\"` 易受文案漂移影响。现 host 跟随配置，判定优先解析 JSON 根 `message` 字段。
+- **`BaseUrlRegex` 贪婪匹配误判 query 为端口**：原正则 `http.*:\d+` 会将 `http://host/path?x=1:2` 中 query 的 `:数字` 误判为端口。现收紧为 `^https?://[^/:]+:\d+`。
 
 ### 改进
 
@@ -17,10 +21,12 @@
 ### 安全性
 
 - **Widevine 许可证请求禁跟随重定向**：许可证 POST 的请求体是设备私钥签名的 challenge，原 `VerifiedAppHttpClient`（允许自动重定向）会在 307/308 上连同 body 重放到跨主机目标。新增 `VerifiedNoRedirectClient`（始终校验证书 + 禁自动重定向，独立连接池不受 `--insecure` 降级），3xx 显式报错不跟随（与 gRPC POST 的凭据收口同构）。
+- **serve 认证失败限速字典有界裁剪**：防止攻击者使用大量独立 IP 或伪造 XFF 标头导致限速记录字典无界增长，在超过上限 `MaxTrackedAuthFailureIps` 时按最后失败时间自动裁剪，保留最近活跃记录。
+- **登录轮询跟随重定向逐跳可信主机校验**：`GetWebSourceWithSetCookiesAsync` 切换为禁自动跳转客户端手动逐跳，每跳发起前校验 `IsTrustedCookieHost`，防止重定向将用户凭证及下发的 `Set-Cookie` 泄露至不可信主机。
 
 ### 测试增强
 
-- 全库测试 640 例（新增 6 例）：VerifiedNoRedirectClient 身份稳定性、GET/POST 307 不跟随（含自动跳转客户端对照）、配置合并 URL 形值选项回归与位置参数提取器语义。
+- 全库测试 659 例（新增 25 例）：VerifiedNoRedirectClient 身份稳定性、GET/POST 307 不跟随、配置合并 URL 形值选项回归、章节前缀清理、认证字典限速有界裁剪、已完成任务溢出按创建时间排序、大会员 JSON message 字段解析、BaseUrlRegex 严格匹配、登录轮询逐跳重定向安全拦截与合法跟随等。
 
 ## [1.6.16] - 2026-08-19
 

--- a/docs/REVIEW_FINDINGS.md
+++ b/docs/REVIEW_FINDINGS.md
@@ -15,6 +15,12 @@
 | RF-5 | ffmpeg `creation_time` 元数据格式文化敏感 | Low | 一行修复（InvariantCulture） | ✅ 已修复（第 9 轮） |
 | RF-6 | mp4box `-itags` cover 值未走 EscapeString | Low（一致性） | 一行修复（补 EscapeString） | ✅ 已修复（第 9 轮） |
 | RF-7 | 配置合并 cliHasUrl 把选项值误判为 URL | Low | 启发式收紧（仅扫描位置参数） | ✅ 已修复（第 9 轮） |
+| RF-8 | FLV 跳过路径不清理封面/字幕/章节（残留累积） | Medium | 与 DASH 分支清理对齐 | ✅ 已修复（第 11 轮） |
+| RF-9 | serve 认证失败限速字典无界增长 | Medium | 超上限按最后失败时间裁剪 | ✅ 已修复（第 11 轮） |
+| RF-10 | serve 已完成任务溢出裁剪按完成顺序误删 | Low | 按 TaskCreateTime 保留最新 | ✅ 已修复（第 11 轮） |
+| RF-11 | Parser 大会员回退硬编码域名 + 子串判定脆弱 | Medium | EpHost 配置化 + JSON message 解析 | ✅ 已修复（第 11 轮） |
+| RF-12 | `BaseUrlRegex` 贪婪匹配误判 query 为端口 | Low | 正则收紧 | ✅ 已修复（第 11 轮） |
+| RF-13 | 登录轮询跟随重定向缺逐跳校验（凭据外发面） | Low | NoRedirect + 每跳可信校验 | ✅ 已修复（第 11 轮） |
 
 ---
 
@@ -99,6 +105,69 @@
 - **定性**：预存启发式的精度问题；触发需要"URL 在配置文件 + 命令行恰好有 URL 形值选项"的组合，真实概率低。
 - **结论**：收紧方向——只对"首个非选项 token"（Spectre 位置参数的位置）应用 UrlLikeToken，或先按 aliasMap 跳过带值选项再扫描（`IsSubCommandInvocation` 已有同构跳过逻辑可复用）。改动属行为微调，建议带回归用例（CLI 传 `--aria2c-proxy http://...` + 配置含 URL）单独落地。
 - **状态**：✅ 已修复（2026-08-29，第 9 轮）：新增 `GetPositionalTokens`（与 `IsSubCommandInvocation` 同构：带值选项吞下一 token、bool 开关与 `--opt=value` 不吞），`cliHasUrl` 只对位置参数应用 UrlLikeToken。`ConfigMergeTests` 新增 3 例回归：`--aria2c-proxy` URL 形值/`--work-dir` av123 形值不再压制配置文件 URL（配置 URL 与选项值均正确合并）、位置参数提取器跳值语义。
+
+---
+
+## RF-8：FLV 跳过路径不清理封面/字幕/章节（残留累积）
+
+- **位置**：`BBDown/Application/Download.cs` — FLV 分支"文件已存在跳过"路径（约 :947-958）。
+- **发现**：DASH 分支的跳过清理（:683-704）会清理本次已下载的封面/字幕/章节并删除空 aid 目录；FLV 分支的跳过路径**只**尝试删空目录，不清理封面/字幕/章节。用户重跑已下载视频时，封面/字幕/章节文件在 aid 工作目录反复累积，且目录非空导致空目录删除逻辑永远不触发。
+- **定性**：真实残留累积（每重跑一次多一套文件）；非安全/数据损坏问题。
+- **核实附带发现**：清理章节用固定名 `chapters`（`Path.Combine(dir, "chapters")`），而 muxer 写入的是**唯一名** `chapters-{basename}`（`BBDownMuxer.cs:136,324`，防并发混流互相覆盖）——旧清理路径根本删不到实际写入的文件，属预存不一致（`BBDownMuxer` 自身 finally 会清理自己的产物，但跳过路径不经过 muxer）。
+- **结论**：收敛为 `Program.DeleteResidualChapterFiles(dir)`：按 `chapters*` 前缀匹配两种命名兜底清理；单文件清理失败静默（IO/句柄异常不掩盖主流程结果）。FLV 跳过路径补封面/字幕清理，与 DASH 分支对齐；fastSkipChecked 跳过路径（:208-223）补章节清理。
+- **状态**：✅ 已修复（2026-08-30，第 11 轮）+2 测试（前缀清理含固定名/唯一名/不误删其它文件；目录缺失不抛）。
+
+---
+
+## RF-9：serve 认证失败限速字典无界增长
+
+- **位置**：`BBDown/Infrastructure/BBDownApiServer.cs` — `IsAuthLockedOut` / `_authFailures`（:49, :511）。
+- **发现**：`IsAuthLockedOut` 的字典清理只移除**窗口过期**条目（`now - last > 1min`）。攻击者用大量一次性 IP/XFF 值轰炸时，每条都是"最近失败"永不过期——仅删过期条目约束不住字典大小，字典随攻击 IP 数线性增长（内存 DoS）。
+- **定性**：Medium（攻击者可控输入面的无界增长；需要持续伪造新 XFF 值，但 serve 已放行 `--trusted-proxy` 场景下 XFF 由代理注入，攻击者不可直接控制——真实触发需攻击者能控制直连来源 IP 或代理透传，触发面中低，但修复成本极低）。
+- **结论**：超过 `MaxTrackedAuthFailureIps` 时先清过期，仍超限则按最后失败时间裁剪回上限（保留最近活跃的 N 条）。O(n log n) 仅在异常规模触发，正常路径零开销。
+- **状态**：✅ 已修复（2026-08-30，第 11 轮）+1 测试（反射验证 1.2 倍上限独立 IP 轰炸后字典 ≤ 上限+1）。
+
+---
+
+## RF-10：serve 已完成任务溢出裁剪按完成顺序误删
+
+- **位置**：`BBDown/Infrastructure/BBDownApiServer.cs` — `TrimFinishedTasksLocked`（:675）。
+- **发现**：`finishedTasks` 列表按**完成顺序**追加（`finishedTasks.Add`），与 `TaskCreateTime`（创建顺序）无关。旧实现溢出时 `RemoveRange(0, count - MaxFinishedTasks)` 删除列表头部——若某任务"后创建但先完成"排在头部，会被误删，而更旧的尾部任务被保留，与"保留最新任务"的意图相反。
+- **定性**：Low（需任务完成顺序与创建顺序显著倒挂才可见；真实场景批量并发任务下确有概率）。
+- **结论**：溢出裁剪改为按 `TaskCreateTime` 排序，仅移除最旧创建的溢出条目，保留其余任务原顺序（API 按完成顺序展示）。
+- **状态**：✅ 已修复（2026-08-30，第 11 轮）+1 测试（构造"后创建先完成"在头部的列表，验证保留最新创建、裁剪最旧创建）。
+
+---
+
+## RF-11：Parser 大会员回退硬编码域名 + 子串判定脆弱
+
+- **位置**：`BBDown.Core/Parser.cs` — 大会员回退（:87-101）。
+- **发现**（两处）：
+  - 回退抓取网页源硬编码 `https://www.bilibili.com/bangumi/play/ep{epId}`，忽略 `Config.Current.EpHost`（镜像站/BiliPlus 配置）——镜像站用户该回退必然失败（被重定向回可能不可达的官方域名）。
+  - 大会员判定用裸子串 `webJson.Contains("\"大会员专享限制\"")`——B 站改文案即失效（历史上文案从"大会员专享限制"演进来过）。
+- **定性**：Medium（镜像站用户的真实功能缺陷 + 文案漂移脆弱性）。
+- **结论**：回退 host 跟随配置（默认配置行为逐字节不变：`EpHost == "api.bilibili.com"` 时用 `www.bilibili.com`，否则用配置的镜像主机）；判定改解析 JSON 根 `message` 字段（`code:-10403, message:大会员专享限制`），非 JSON 响应（风控 HTML）才回退子串兜底。
+- **状态**：✅ 已修复（2026-08-30，第 11 轮）+2 测试（`IsVipRestrictedResponse` JSON message 5 例 + 非 JSON 兜底 2 例）。
+
+---
+
+## RF-12：`BaseUrlRegex` 贪婪匹配误判 query 为端口
+
+- **位置**：`BBDown.Core/Parser.cs` — `BaseUrlRegex`（:751）。
+- **发现**：原正则 `http.*:\d+` 未锚定 scheme 后立即匹配主机:端口，会把 `http://host/path?x=1:2` 这类 URL 的 query 中 `:数字` 误判为端口——若该 URL 实际无端口，基址推导错误（虽然实际使用中 CDN URL 通常带端口，但 query 参数含时间戳/签名时可能误判）。
+- **定性**：Low（当前使用点 `PickTrackBaseUrl` 的输入为合法 CDN URL，query 带 `:数字` 的场景罕见；正则语义与"提取主机:端口"意图不符是确定性代码缺陷）。
+- **结论**：收紧为 `^https?://[^/:]+:\d+`（锚定起点、主机段不含 `/`/`:`、冒号后必须数字）。
+- **状态**：✅ 已修复（2026-08-30，第 11 轮）+1 测试（6 例：带端口匹配 / query `:数字` 不误判 / 无端口不匹配 / 缺 scheme 不匹配）。
+
+---
+
+## RF-13：登录轮询跟随重定向缺逐跳校验（凭据外发面）
+
+- **位置**：`BBDown.Core/Util/HTTPUtil.cs` — `GetWebSourceWithSetCookiesAsync`（:217）。
+- **发现**：登录轮询（扫码后轮询二维码状态）携带操作者 Cookie 且响应 `Set-Cookie` 是新凭证下发通道，却使用自动跟随重定向的 `AppHttpClient`——被攻破的 passport 域名或开放重定向可把带凭据的请求与响应 `Set-Cookie` 凭证引向任意主机。与同文件 `GetWebSourceAnonymousCheckedAsync`（匿名逐跳校验）、B3-F2 gRPC POST、RF-4 Widevine 的收口原则不一致。
+- **定性**：Low（纵深防御缺口；入口 URL 为硬编码可信 passport 端点，无当前可利用面；原则一致性修复）。
+- **结论**：改用 `NoRedirectClient` 手动逐跳，每跳 Location 在发起下一跳前必须通过 `IsTrustedCookieHost`，上限 `MaxRedirectHops=10`；与现有 `GetWebSourceCoreAsync` 的 5xx 重试/时钟校准语义保持一致。
+- **状态**：✅ 已修复（2026-08-30，第 11 轮）+2 测试（非可信重定向抛错且不访问下一跳 / 可信同主机重定向跟随成功返回 body）。
 
 ---
 

--- a/docs/REVIEW_PLAN.md
+++ b/docs/REVIEW_PLAN.md
@@ -173,6 +173,22 @@
 | 测试 | ✅ ServeApiHttpTests 适配：RunningServer 直用 `RunAsync`、NonLoopbackListen 改断 `ValidateListenUrl` 同步异常语义；单测 640/640 全绿（PR gate 过滤器）+ LocalIntegration 3/3 |
 | 基线 | ✅ dotnet build Release 0 警告 0 错误；dotnet format --verify-no-changes 通过；serve 冒烟：`--help` 退出码 0、serve 监听回环、`/get-tasks/running` 200 |
 
+## 第 11 轮：RF-2 迁移后全库续审 + 新发现消纳（2026-08-30）
+
+> 本轮为 RF-2 合入后的续审：核实迁移质量 + 四路并行深查（下载管线 / serve 服务 / Core 解析网络层 / 测试套件），产出 8 个新发现（3 Medium + 5 Low，登记 REVIEW_FINDINGS RF-8..RF-13）并**全部修复**（含回归测试）。
+
+| 项 | 处理 |
+|----|------|
+| RF-2 迁移后核实 | ✅ 8 命令 AsyncCommand 语义逐字保留、serve `ValidateListenUrl`+`RunAsync` 拆分合理、无残留 async-over-sync 阻塞（仅 ExternalToolHelper 短进程探针例外，文档已说明）；基线 build 0 警告 0 错误、单测 640/640、format 通过 |
+| serve 冒烟 | ✅ 回环启动 `/get-tasks/running`+`/finished` 200；非回环无 token 拒绝启动且退出码 1（遗留 serve 进程 31152 锁 DLL，已确认来源并终止） |
+| RF-8 | ✅ Download.cs FLV 跳过路径清理与 DASH 分支对齐（封面/字幕/章节），fastSkipChecked 路径补章节清理；新增 `DeleteResidualChapterFiles` 按前缀兜底清理（muxer 写 `chapters-{basename}` 唯一名，旧清理只删固定名 `chapters` 是预存不一致）；+2 测试 |
+| RF-9 | ✅ BBDownApiServer 认证失败限速字典超过 `MaxTrackedAuthFailureIps` 时按最后失败时间裁剪（仅删过期条目约束不住新 IP 轰炸）；+1 测试（反射验证字典有界） |
+| RF-10 | ✅ `TrimFinishedTasksLocked` 溢出裁剪按 `TaskCreateTime` 保留最新（旧 `RemoveRange(0,...)` 按完成顺序误删"后创建先完成"任务）；+1 测试 |
+| RF-11 | ✅ Parser 大会员回退 host 改用 `Config.Current.EpHost`（镜像站可用）；回退判定改解析 JSON `message` 字段（子串匹配仅作非 JSON 兜底，防 B 站改文案失效）；+2 测试 |
+| RF-12 | ✅ `BaseUrlRegex` 收紧为 `^https?://[^/:]+:\d+`（query 中 `:数字` 不再误判为端口）；+1 测试 |
+| RF-13 | ✅ `GetWebSourceWithSetCookiesAsync`（登录轮询）改 `NoRedirectClient` 手动逐跳 + 每跳 `IsTrustedCookieHost` 校验（与 gRPC/Widevine 收口同构，凭据与响应 Set-Cookie 不外发非可信主机），上限 `MaxRedirectHops=10`；+2 测试 |
+| 基线 | ✅ dotnet build Release 0 警告 0 错误；单测 659/659 全绿（PR gate 过滤器，新增 19 例）；dotnet format --verify-no-changes 通过 |
+
 ---
 
 ## 已完成批次（git log 13766b0..2ab54d1，2026-08）


### PR DESCRIPTION
## 变更内容

### 修复与安全性加固
1. **RF-8**：FLV 跳过路径补充清理本次下载但未消费的元数据文件（封面/字幕/章节），与 DASH 分支行为对齐；章节文件按 \chapters*\ 前缀兜底清理（解决 muxer 写 \chapters-{basename}\ 唯一名在跳过/失败路径残留的问题）。
2. **RF-9**：\BBDownApiServer\ 认证失败限速字典在超出上限 \MaxTrackedAuthFailureIps\ 时按最后失败时间自动裁剪，保留最近活跃记录，防止恶意 IP 轰炸导致字典无界增长。
3. **RF-10**：\TrimFinishedTasksLocked\ 溢出裁剪改为按 \TaskCreateTime\ 排序移除最旧创建的任务（修复旧实现按完成顺序误删后创建先完成任务的问题）。
4. **RF-11**：番剧大会员回退网页抓取 URL host 跟随 \Config.Current.EpHost\（镜像站可用）；大会员回退判定改为解析 JSON 根对象的 \message\ 字段（子串匹配仅作非 JSON 兜底）。
5. **RF-12**：\BaseUrlRegex\ 正则收紧为 \^https?://[^/:]+:\\d+\，避免 URL query 中的 \:数字\ 误判为端口。
6. **RF-13**：\HTTPUtil.GetWebSourceWithSetCookiesAsync\（登录轮询）改用 \NoRedirectClient\ 手动逐跳 + 逐跳 \IsTrustedCookieHost\ 校验（凭据与响应 Set-Cookie 纵深防御），上限 \MaxRedirectHops = 10\。

### 文档与测试
- 更新 \docs/REVIEW_FINDINGS.md\ 登记 RF-8~RF-13 并标记已修复。
- 更新 \docs/REVIEW_PLAN.md\ 登记第 11 轮审查记录。
- 更新 \CHANGELOG.md\ [未发布] 修复、安全与测试增强条目。
- 全库测试 659 例（新增 19 例全部通过）。
- \dotnet format BBDown.sln --verify-no-changes\ 校验通过。