### PR TITLE
docs: 第 12 轮全库审查登记（RF-14~RF-29）+ fork 与上游差异文档

### DIFF
--- a/docs/FORK_DIFFERENCES.md
+++ b/docs/FORK_DIFFERENCES.md
@@ -1,0 +1,101 @@
+# 本 fork 与上游差异（FORK_DIFFERENCES）
+
+> **用途**：记录 aliveranme/BBDown（本仓库）相对上游 [nilaoda/BBDown](https://github.com/nilaoda/BBDown) 的实质性差异，供同步上游、发布说明与协作者快速对齐认知。
+> **快照基准**：本 fork `master` @ `11bc7fc`；上游 `master` @ `259a555`（适配新版空间合集/系列链接，#1077）。merge-base 即上游顶端——本 fork 领先上游 **313 个提交**，上游无未合入提交。总量：221 文件，+30,446 / −5,121 行。
+> **更新时机**：每次合入上游新提交或本 fork 发版后，更新"快照基准"与受影响条目（见文末维护说明）。
+
+---
+
+## 一、上游已具备、本 fork 继承并大幅演进的能力
+
+避免"把上游既有能力误记为本 fork 新增"，先列这一节：
+
+| 能力 | 上游状态（259a555） | 本 fork 演进 |
+|------|--------------------|--------------|
+| `serve` / API 服务 | `BBDownApiServer.cs` 约 210 行极简任务 API | 约 1,460 行：任务队列/JobId 契约、认证限速、CSRF/Origin 校验、webhook 回调 SSRF 防护、任务持久化、订阅任务接入（详见 2.4） |
+| Native AOT | `net9.0` + `PublishAot=true`（`Directory.Build.props` 已有） | 升级 `net10.0`；修复系列 AOT 运行时崩溃（Spectre CommandSettings 元数据保留等）；新增 `AotCliBindingTests` 防 CLI 选项绑定回归 |
+| Dockerfile | 存在 | 按 AOT SDK 镜像重建（`sdk:10.0-aot` 构建 + `runtime-deps:10.0` 运行）、非 root 用户、默认拒绝非回环无 token 启动 |
+| 8 个 Fetcher / Parser / HTTPUtil / SubUtil | 存在 | 深度重构与加固（防御性解析、重试、脱敏），差异见三、四节 |
+
+## 二、用户可见的功能差异
+
+### 2.1 CLI 命令框架与子命令
+
+- 命令框架：System.CommandLine（上游）→ **Spectre.Console.Cli**（本 fork），8 个命令全部 `AsyncCommand`（无线程池阻塞）。
+- 上游仅 3 个子命令：`login` / `logintv` / `serve`。
+- 本 fork 新增 4 个子命令：
+
+| 子命令 | 功能 | 关键实现 |
+|--------|------|---------|
+| `live` | 直播录制 | `LiveStreamUtil`（FLV 分段、读停滞看门狗、短段退避重连、TrimFlvTail） |
+| `sub` | 订阅下载 | `SubscriptionStore`（持久化、幂等、有界历史 5000 + 损坏隔离） |
+| `article` | 评论/文章保存 | `CommentUtil` / `ArticleUtil` |
+| `watchlater` | 稍后再看批量下载 | 复用批量管线 |
+
+### 2.2 DRM / Widevine 解密（全新，上游无 `BBDown.Core/DRM/`）
+
+- 课程 CKC 协议（`CkcDecryptor`）+ 番剧 `drm_tech_type=2` Widevine（`WidevineCdm` / `WidevineCrypto` / `WvdDevice`）。
+- 仓库打包 `device.wvd`（一键解密）；配套 Chrome 扩展提取密钥。
+- 新选项：`--decrypt-drm`、`--key`、`--kid`、`--wvd-path`、`--mp4decrypt-path`。
+
+### 2.3 serve / API 服务（上游 210 行 → 本 fork 约 1,460 行）
+
+- 任务生命周期：`/add-task` 返回 JobId、`/cancel` 全程可取消、`/remove-finished`、`/get-tasks` 族查询（并发信号量上限 8，超限 429）。
+- 安全边界：`X-Serve-Token` 常量时间比较 + 失败限速有界裁剪；写端点 Origin/CSRF 校验；webhook 回调三重 SSRF 防护（启动 allowlist + 每次复查 + 禁重定向）；`SanitizeUntrustedOptions` 清零客户端危险字段（路径/UA/ForceHttp/DRM 密钥等 17+ 字段）+ 数值 Clamp 防慢速 DoS。
+- 持久化：任务记录 tmp+flush+rename 原子落盘、已完成任务上限 1000 + 30 天保留。
+- 新选项：`--max-concurrent`、`--serve-token`（环境变量 `BBDOWN_SERVE_TOKEN` 优先）、`--trusted-proxy`、`--notify-webhook`。
+- 用户文档：根目录 `API.md`（取代上游 `json-api-doc.md`，后者已删除）。
+
+### 2.4 新增 CLI 选项（15 个，上游 57 个全部保留、零删除）
+
+| 主题 | 选项 |
+|------|------|
+| DRM | `--decrypt-drm`、`--key`、`--kid`、`--wvd-path`、`--mp4decrypt-path` |
+| 韧性 | `--retry-count`、`--retry-delay`、`--muxer-timeout`、`--thread-segment-size` |
+| 行为 | `--allow-preview`（充电专属预览检测，不静默保存）、`--insecure`（跳过 TLS 校验，serve 下强制清零） |
+| 弹幕/评论 | `--comments`、`--danmaku-filter`、`--danmaku-filter-user` |
+| serve | `--notify-webhook` |
+
+### 2.5 下载与解析韧性（上游基本裸奔的行为面）
+
+- `.tmp` 分片断点续传（含 Content-Range 身份校验防串台）、多线程分片尺寸错位修复、跳过路径假成功复核。
+- `CancellationToken` 贯通网络/下载/登录轮询/更新检查全链路（上游多处不可取消）。
+- 风控页识别（200+HTML）参与页面级重试；Cookie 过期显式检测报告；签名 URL 日志脱敏。
+
+## 三、安全差异（相对上游的系统性加固）
+
+| 层 | 差异 |
+|----|------|
+| HTTP | 连接池按策略隔离（verified/insecure × 自动/禁重定向 × media 下载），`--insecure` 不可降级 verified 池；重定向逐跳可信主机校验（登录轮询/gRPC/Widevine）；Cookie 外发主机白名单；gzip 解压 48MB 上限；gRPC 帧首字节校验 |
+| 时钟/WBI | `ServerClock` 服务端时钟校准（不可信源隔离防 WBI 扰动）；`BuvidProvider` 设备指纹；WBI 签名流内传播 |
+| 凭据/日志 | `SensitiveDataMasker`（签名 URL/Cookie/WBI key 脱敏）、`SanitizeServerText` 控制字符剥离、异常消息路径脱敏、serve 日志单行化 |
+| 本地执行 | 外部工具搜索仅 `APP_DIR`/`PATH`、绝不搜 CWD（防可执行劫持）；`RiskControlResponseException` / `UpowerGuard` 防御性解析 |
+| serve 面 | 见 2.3（认证/CSRF/限速/SSRF/Clamp 全家桶） |
+
+## 四、工程与流程差异（上游均无）
+
+- **测试**：`BBDown.Tests`（xUnit，659 例全绿，上游无任何测试项目）——`failSkips: true` 防静默跳过、`FakeBilibiliApiServer` + 14 场景夹具护栏锁 `ExtractTracksAsync` 主干、Local/NetworkIntegration 分层（ffmpeg 在位检测）。
+- **CI/CD**：`pr.yml`（单测 gate + `dotnet format --verify-no-changes` 硬门禁 + 本地集成）、`codeql.yml`、`release.yml` / `build_latest.yml`（多平台 AOT 产物 + Docker 冒烟）、dependabot、issue/PR 模板、CODEOWNERS。
+- **约束**：`global.json`（SDK 10.0.300 pin）、`.editorconfig` / `.gitattributes`（UTF-8、LF、4 空格、末尾换行）、`AGENTS.md`（代理协作规范）、`CONTRIBUTING.md` / `SECURITY.md` / `CODE_OF_CONDUCT.md`。
+- **文档**：README 全面重写、`API.md`、`CHANGELOG.md`（Keep a Changelog）、`docs/wiki/` 15 页 + `scripts/sync-wiki.ps1`、`docs/REVIEW_PLAN.md` / `REVIEW_FINDINGS.md` / `MAINTENANCE_PLAN.md`（12 轮审查体系）。
+- **结构重组**：`BBDown/` 平铺 → `Commands/` `Infrastructure/` `Application/` `Configuration/` `Utilities/` 分层；`BBDown.Core` 新增 `DRM/`、`Util/` 扩充（`PathUtil`、`JsonElementExtensions`、`SensitiveDataMasker` 等）；删除 `launchSettings.json`。
+
+## 五、向后兼容承诺
+
+- 上游 57 个 CLI 选项**全部保留**（含 `--bandwith-ascending` 历史拼写兼容），零删除。
+- `BBDown.config` 键格式不破坏。
+- `login` / `logintv` / `serve` 语义保持（serve 行为强化，默认无 token 回环监听仍可用）。
+
+## 六、同步上游注意事项
+
+1. 上游推进后先 `git fetch upstream`，`git merge upstream/master`（本 fork 未 rebase 改写历史，merge 保留双方脉络）。
+2. 冲突热点（本 fork 深度重构文件）：`Parser.cs`、`HTTPUtil.cs`、`BBDownApiServer.cs`、`MyOption.cs`、`SubUtil.cs`、各 Fetcher。
+3. 合并后必跑基线三件套：`dotnet build BBDown.sln -c Release` → PR gate 过滤器单测 → `dotnet format BBDown.sln --verify-no-changes`（见 AGENTS.md）。
+4. 上游侧差异对齐检查：上游若新增 CLI 选项/子命令，对照本文 2.1/2.4 评估是否采纳并更新；上游若改 `serve`，注意本 fork 安全边界（SanitizeUntrustedOptions 等）不可被合并回退。
+5. 上游的 `json-api-doc.md` 已在本 fork 删除（被 `API.md` 取代）；上游若恢复或修改该文件，冲突时以 `API.md` 为准。
+
+## 七、维护本文档
+
+- **更新时机**：合入上游提交后、每个 fork 版本发布后。
+- **更新内容**：头部快照基准（commit、领先/落后计数）；受影响章节（新子命令/新选项/新能力进二节；安全批次进三节；工程变化进四节）。
+- **生成方式**：`git fetch upstream && git merge-base master upstream/master` 取基准；`git rev-list --count` 取领先/落后；`git diff --stat upstream/master..master` 取规模；CLI 选项对比可从上游 `CommandLineInvoker.cs` 与本 fork `BBDown/Configuration/MyOption.cs` 提取 `--xxx` 记号比对。

--- a/docs/REVIEW_FINDINGS.md
+++ b/docs/REVIEW_FINDINGS.md
@@ -21,6 +21,22 @@
 | RF-11 | Parser 大会员回退硬编码域名 + 子串判定脆弱 | Medium | EpHost 配置化 + JSON message 解析 | ✅ 已修复（第 11 轮） |
 | RF-12 | `BaseUrlRegex` 贪婪匹配误判 query 为端口 | Low | 正则收紧 | ✅ 已修复（第 11 轮） |
 | RF-13 | 登录轮询跟随重定向缺逐跳校验（凭据外发面） | Low | NoRedirect + 每跳可信校验 | ✅ 已修复（第 11 轮） |
+| RF-14 | 下载管线两级 catch 过滤器缺口（NotSupportedException/AggregateException 逃逸） | Medium | 采纳（改抛 InvalidOperationException + 过滤器补 AggregateException） | ⏳ 待排期 |
+| RF-15 | serve 读端点无 Host 校验（DNS rebinding 读面） | Medium | 采纳（isApi 加 Host 回环白名单） | ⏳ 待排期 |
+| RF-16 | 文档正确性族（wiki 退出码表虚构 2/3、CLI-Reference 缺 4 选项、README serve 列举不完整） | Medium（文档） | 采纳（修正文档） | ⏳ 待排期 |
+| RF-17 | Parser 免二压重发吞用户取消（两处 catch 缺取消守卫） | Low | 采纳（补 OperationCanceledException 重抛守卫） | ⏳ 待排期 |
+| RF-18 | 服务器可控 lan/audio_id 未净化直拼文件路径 + SubOnly ASS 改名 .srt | Low | 采纳（GetValidFileName 净化 + 按源扩展名改名） | ⏳ 待排期 |
+| RF-19 | publishDate/videoDate 占位符 culture 敏感且替换值未净化 | Low | 采纳（InvariantCulture + GetValidFileName） | ⏳ 待排期 |
+| RF-20 | 跳过路径清理一致性残留（锁内 Skipped 漏 coverPath、dash 跳过路径裸删） | Low | 采纳（与 flv 分支对齐） | ⏳ 待排期 |
+| RF-21 | aria2c stdin input-file 换行注入面 | Low | 采纳（写前剔除 \r\n） | ⏳ 待排期 |
+| RF-22 | 进程执行边界（探针未观察管道任务；成功路径 5s 兜底翻转成功） | Low | 部分采纳（探针改异步执行器；成功路径语义先确认） | ⏳ 待排期 |
+| RF-23 | mp4box 输出 `.muxing-{guid}` 未知扩展名兼容性 | Low | 待议（需 GPAC 实测后定） | ⏳ 待议 |
+| RF-24 | SanitizeUntrustedOptions 漏 interactive | Low | 采纳（一行清零） | ⏳ 待排期 |
+| RF-25 | 解析失败日志 option.Url 未单行化（两处） | Low | 采纳（补 SanitizeLogString） | ⏳ 待排期 |
+| RF-26 | Core 解析/网络健壮性低危族（5 小项） | Low | 采纳（随批次逐项落地） | ⏳ 待排期 |
+| RF-27 | FindBinaries 进程级静态工具路径（serve 并发理论面） | Low | 待议（倾向维持现状：Sanitize 已清零路径字段） | ⏳ 待议 |
+| RF-28 | HTTP 响应体无大小上限 | Low | 采纳（逐块读取设总量上限） | ⏳ 待排期 |
+| RF-29 | .editorconfig 存量违规 4 文件（BOM/末尾换行） | Low | 采纳（重存文件；可补轻量检查） | ⏳ 待排期 |
 
 ---
 
@@ -168,6 +184,165 @@
 - **定性**：Low（纵深防御缺口；入口 URL 为硬编码可信 passport 端点，无当前可利用面；原则一致性修复）。
 - **结论**：改用 `NoRedirectClient` 手动逐跳，每跳 Location 在发起下一跳前必须通过 `IsTrustedCookieHost`，上限 `MaxRedirectHops=10`；与现有 `GetWebSourceCoreAsync` 的 5xx 重试/时钟校准语义保持一致。
 - **状态**：✅ 已修复（2026-08-30，第 11 轮）+2 测试（非可信重定向抛错且不访问下一跳 / 可信同主机重定向跟随成功返回 body）。
+
+---
+
+## RF-14：下载管线两级 catch 过滤器缺口（NotSupportedException/AggregateException 逃逸）
+
+- **位置**：`BBDown/Infrastructure/BBDownDownloadUtil.cs:797-801`（抛出点）、`BBDown/Application/Download.cs:1067`（页面级重试过滤器）、`Download.cs:94`（批级失败上报过滤器）。
+- **发现**：多线程下载路径在"服务器以 200 响应多线程 Range 请求"时**刻意抛出** `NotSupportedException`（真实可发生的运行时条件：某 CDN 忽略 Range），`:799-801` 还原样重抛 `ArgumentException`；但页面级与批级两级过滤器白名单均只有 `HttpRequestException or JsonException or IOException or InvalidOperationException or TimeoutException (or TaskCanceledException)`。`Parallel.ForEachAsync` 多分片同时失败聚合出的 `AggregateException` 同样不在内（`IsSizeArtifactFailure` 在 :914-916 专门处理过它，证明作者知晓其存在）。异常经 `:830/:837` `ExceptionDispatchInfo` 原样重抛，途中不会被包装。
+- **影响**：多 P 批量中一 P 命中即穿透 `DownloadPagesAsync` 的 foreach，剩余分 P 全弃、`NotifyWebhook` 与 `failedPages` 汇总全丢、退出码语义与单 P 失败不一致——与管线精心建立的"单 P 失败隔离"设计矛盾。`EnsureToolAvailable` 的注释（BBDownMuxer.cs:56-59）记录了同构问题（FileNotFoundException 当时正是为此改抛 InvalidOperationException），`NotSupportedException` 是漏网的同族。
+- **结论**：采纳修复，三选一（按侵入度递增）——(a) :797 改抛 `InvalidOperationException`（与 EnsureToolAvailable 同一先例，最小改动）；(b) 扩充两级过滤器加入 `NotSupportedException or ArgumentException or AggregateException`（AggregateException 拆包取首个 InnerException 判断）；(c) 在 MultiThreadDownloadCoreAsync 抛出点统一规范化为页面级白名单类型。建议 (a) + 过滤器补 AggregateException。
+- **状态**：⏳ 待排期（第 12 轮登记，Medium 级已人工逐行核实）。
+
+---
+
+## RF-15：serve 读端点无 Host 校验（DNS rebinding 读面）
+
+- **位置**：`BBDown/Infrastructure/BBDownApiServer.cs:171-216`（中间件：只对写端点校验 Origin，:172 注释明确豁免读端点）、`:238-279`（读端点返回完整快照）、`BBDown/Application/Download.cs:211`（`AddSavePath(savePath)` 存入 `PathUtil.ResolveWorkPath` 解析后的**绝对路径**）。
+- **发现**：默认部署（回环监听、无 token）下，`/get-tasks*` 响应含 SavePaths（服务器绝对文件路径）、标题、URL、错误消息，但无任何 Host 头校验（全仓库无 AllowedHosts 过滤，Kestrel 默认 `AllowedHosts=*`）。攻击者网页经 DNS rebinding（攻击者域名 → 127.0.0.1）后，页面源即 `http://evil.com:23333`，对 `/get-tasks` 的 GET 是"同源"请求——不携带 Origin（fetch 同源 GET 不发 Origin），写端点的 Origin 校验对读端点不生效，且单加 Origin 校验也堵不住。写端点本身无恙：POST 必带 Origin（Fetch 规范非 GET/HEAD 必发），被 `IsLoopbackOrigin` 拦截。
+- **定性**：Medium（信息泄露面真实；前提是用户浏览器访问攻击者页面 + 本机 serve 正在运行，泄露的是文件系统布局与任务元数据，非凭据）。
+- **结论**：在 isApi 分支增加 **Host 头白名单**（`context.Request.Host.Host` 必须解析为回环地址或 localhost，否则 403/404）——curl/脚本直连 127.0.0.1/localhost 不受影响，同时封死 rebinding 的读写两条路；作为纵深也可给读端点加"非回环 Origin 即 403"，或将 `SavePaths` 从无 token 模式的响应中脱敏。
+- **状态**：⏳ 待排期（第 12 轮登记，Medium 级已人工逐行核实）。
+
+---
+
+## RF-16：文档正确性族（wiki 退出码表 / CLI-Reference 缺项 / README 列举不完整）
+
+- **位置**：`docs/wiki/CLI-Reference.md:112-121`（退出码表）、`:1,:27`（自称"完整参数详解/完整参数速查总表"）、`README.md:333`。
+- **发现**（三处）：
+  - 退出码表声称 `2 = Permission Denied（充电专属视频）`、`3 = Tool Missing`，并把"用户主动 Ctrl+C"归入 `0`。但全仓库 `return 2/3;`、`Environment.Exit(2/3)` **零命中**：充电专属无 `--allow-preview` 时走 `Download.cs:489-493` 的 `return false`（跳过分 P，进程正常 0 退出）；工具缺失（FindBinaries 的 FileNotFoundException）走全局 handler 退出 **1**；默认命令 Ctrl+C 返回 **130**（`Program.cs:159-164`），仅 serve/live 等子命令 catch OCE 返回 0。依赖退出码做自动化判断（CI/脚本包装器）的用户会误判。
+  - CLI-Reference 对照 MyOption 65 个选项，反引号精确匹配差集为 `--host`、`--ep-host`、`--tv-host`、`--area`（INTL/TV 端点覆盖选项）4 项缺失；README"核心参数速查"同样缺。
+  - README:333 serve 配置注入说明括号内仅列 `-l`/`--max-concurrent`/`--serve-token`，而 `ServeSettings` 还有 `--trusted-proxy`、`--notify-webhook`（同页 :157-158 表格已列出，前后不一致）。
+- **结论**：采纳修正——(a) 退出码表删除虚构的 2/3 行并改写 Ctrl+C 归属（或实现退出码 2/3，需先定语义）；(b) 补 4 选项行或把标题/总表口径改为"常用参数"；(c) README:333 补全或改"等选项"。
+- **状态**：⏳ 待排期（第 12 轮登记）。
+
+---
+
+## RF-17：Parser 免二压重发吞用户取消（两处 catch 缺取消守卫）
+
+- **位置**：`BBDown.Core/Parser.cs:324`、`:526`（免二压重新请求的 catch 过滤器）。
+- **发现**：两处 `catch (Exception ex) when (ex is ... or TaskCanceledException)` 无 `!token.IsCancellationRequested` 守卫。`:518-519` 注释断言"真正的用户取消（OperationCanceledException，非 TaskCanceledException）不被过滤器捕获"——**前提是错的**：`HttpClient.SendAsync` 在用户 token 取消时抛的正是 `TaskCanceledException`（OperationCanceledException 的子类）。Ctrl+C / serve 关停落在重发请求窗口会被吞掉、记为"降级沿用第一轮结果"，继续走完解析并产生误导性 Warn。项目既有正确模式（`Download.cs:1159`、`UrlResolver.cs:239`、`FavListFetcher.cs:108`）都是先 `catch (OperationCanceledException) when (token.IsCancellationRequested) throw;` 或在过滤器补 `!token.IsCancellationRequested`，唯独这两处漏了。
+- **结论**：采纳一行修复——两个 catch 前插入取消重抛守卫（或在 TaskCanceledException 分支加 `&& !token.IsCancellationRequested` 语义）。
+- **状态**：⏳ 待排期（第 12 轮登记）。
+
+---
+
+## RF-18：服务器可控 lan/audio_id 未净化直拼文件路径 + SubOnly ASS 改名 .srt
+
+- **位置**：`BBDown.Core/Util/SubUtil.cs:247,286,319,357,407`、`BBDown.Core/Parser.cs:502`、`BBDown/Application/Download.cs:444-445`。
+- **发现**（两处）：
+  - `lan`（`lang_key`）、`audio_id` 全部来自响应体（B 站接口 / 镜像站 EpHost / `--insecure` 下的中间人——后两者正是本项目在其他防御中明确采纳的对抗源），未净化直接进 `PathUtil.ResolveWorkPath($"{aid}/{aid}.{cid}.{lan}...")`；`ResolveWorkPath` 只做 Combine 不过滤（含 `..` 与分隔符原样保留），标题类文本都走了 `GetValidFileName`（InvalidChars 含 `/`、`\`），此处是缺口——恶意 `lang_key` 含 `..\` 可把字幕写出 workDir 之外。
+  - SubOnly 分支无条件 `Path.ChangeExtension(_outSubPath, $".{s.lan}.srt")`：ASS 内容字幕（按 URL 形态落盘为 `.ass`）被改名为 `.srt`，播放器无法渲染。`Download.cs:444` 处 `s.lan` 同样未净化进最终产物路径。
+- **结论**：采纳——对 `lan`/`audio_id` 应用 `PathUtil.GetValidFileName`（或白名单 `[A-Za-z0-9_-]`）后再拼路径；SubOnly 按源文件扩展名决定目标扩展名（`.ass` → `.{lan}.ass`）。
+- **状态**：⏳ 待排期（第 12 轮登记）。
+
+---
+
+## RF-19：publishDate/videoDate 占位符 culture 敏感且替换值未净化
+
+- **位置**：`BBDown/Program.cs:48`（`ToString(format)` 未指定 culture）、`BBDown/Application/PathHelper.cs:67-68`（替换值未过 `GetValidFileName`，对照 :51/:54/:58 的 title/pageTitle/ownerName 都过了）。
+- **发现**：`<publishDate:...>`/`<videoDate:...>` 的自定义格式串是用户输入，格式化用 CurrentCulture（`:` 是"时间分隔符"占位符而非字面字符）：en-US 下 `<publishDate:yyyy-MM-dd HH:mm:ss>` 产出含 `:` 的串直接进 savePath——Windows 上可写入 NTFS 备用数据流（`File.Exists` 为真但资源管理器不可见）；fi-FI 等区域设置下 `:` 被替换为本地分隔符导致跨机器产物路径漂移。格式非法串有 FormatException 兜底，但 `:` 产出的是合法格式化结果，兜不住。
+- **结论**：采纳——`FormatTimeStamp` 加 `CultureInfo.InvariantCulture`（与 RF-5 的 creation_time 收口同构）；对 publishDate/videoDate 的替换值再过一次 `GetValidFileName`。
+- **状态**：⏳ 待排期（第 12 轮登记）。
+
+---
+
+## RF-20：跳过路径清理一致性残留（锁内 Skipped 漏 coverPath、dash 跳过路径裸删）
+
+- **位置**：`BBDown/Application/Download.cs:208-225`（锁内权威 Skipped 分支）、`:709`（dash 快速跳过删封面）及 `:613,618,637,459,688`（dash 分支其余裸删）。
+- **发现**（两处）：
+  - 锁内 Skipped 分支清理了 videoPath/audioPath/字幕/音频素材/章节并删空 aid 目录，但**漏了 `coverPath`**——两条锁外快速跳过路径（:709、:976）都删封面，唯独这条锁内权威跳过不删 → 每次走此路径 aid 目录残留一张封面、永远非空删不掉。
+  - dash 分支跳过/提前返回路径的多处裸 `File.Delete`/`Directory.Delete` 无 try/catch，而 flv 分支对应位置（:976-977、:939、:962、:988）全部包了 `catch (IOException or UnauthorizedAccessException)`——封面恰被杀软/索引器持有时裸删抛 IOException → 进入页面级重试（过滤器含 IOException）→ 整页（含已存在产物判定）重跑，占用持续则重试耗尽、已完成的分 P 被记为失败。dash 分支是 RF-8 修复族里漏网的一致性问题。
+- **结论**：采纳——锁内 Skipped 分支补 coverPath 清理；dash 分支裸删统一改用 flv 分支同款包裹（或收敛到统一清理函数）。
+- **状态**：⏳ 待排期（第 12 轮登记）。
+
+---
+
+## RF-21：aria2c stdin input-file 换行注入面
+
+- **位置**：`BBDown/Infrastructure/BBDownAria2c.cs:45-50`。
+- **发现**：aria2c `--input-file=-` 语法是"URI 行 + 缩进行为选项行"，而写入 stdin 的 URL（来自 API 响应的 CDN 地址）与 Cookie（操作者配置）未剔除 `\r`/`\n`——包含换行的 URL 可注入任意新指令行（新 URI + `  dir=`/`  all-proxy=` 等）。合法的 `  dir=`/`  out=` 行在注入点之后会对后续 URI 重新生效，实际危害以行为扰动/自 DoS 为主，但注入面真实存在，与项目"参数一律走 ArgumentList/stdin 防注入"的总体思路不符。
+- **结论**：采纳——URL 与 Cookie 写入前剔除 `\r`/`\n`（一行防御，正常输入零影响）。
+- **状态**：⏳ 待排期（第 12 轮登记）。
+
+---
+
+## RF-22：进程执行边界（探针未观察管道任务；成功路径 5s 兜底翻转成功）
+
+- **位置**：`BBDown/Utilities/ExternalToolHelper.cs:26-33`、`BBDown/Infrastructure/ExternalProcessRunner.cs:90-92`。
+- **发现**（两处）：
+  - `CheckFFmpegDOVI` 用 `WaitForExit(5000)` + `outTask.GetAwaiter().GetResult()` 同步探针（RF-2 迁移时的"短进程探针例外"，但杜比视界命中时每 P 最多卡 5 秒）；超时分支 `process.Kill(true); return false;` 直接返回，`outTask`/`errTask` 未被观察——Kill 后管道断裂可能成为 UnobservedTaskException（ExternalProcessRunner/Decrypt 同类问题都做了观察兜底，此处没有）。
+  - `ExternalProcessRunner` 进程成功退出后 `await Task.WhenAll(pipeTasks).WaitAsync(5s)`——子进程若（罕见地）派生继承 stdout 句柄的孙进程，管道 EOF 超过 5 秒即抛 TimeoutException 进 catch 重抛，混流退出码 0 的成功结果被误报为失败。注释表明作者知晓此权衡，但成功路径与失败路径共用同一超时，语义上把"输出句柄未关"等同于"执行失败"。
+- **结论**：探针改用现成 `ExternalProcessRunner.RunAsync`（超时/整树 Kill/管道观察都有现成实现）；成功路径等待超时后若 `p.HasExited && p.ExitCode == 0` 可仅记警告并返回退出码——先确认是否有意再改。
+- **状态**：⏳ 待排期（第 12 轮登记）。
+
+---
+
+## RF-23：mp4box 输出 `.muxing-{guid}` 未知扩展名兼容性（需实测）
+
+- **位置**：`BBDown/Application/Download.cs:236,240`（混流事务化临时名）、`BBDown/Infrastructure/BBDownMuxer.cs:184`（mp4box 分支把该路径直接作为 `-new` 输出参数）。
+- **发现**：混流事务化把输出统一改为 `savePath + ".muxing-{guid:N}"`。ffmpeg 用 `-f mp4` 强制格式不受影响；但 GPAC 按扩展名推断输出封装格式，`.muxing-xxx` 属未知扩展名——旧版 GPAC（gf_isom_open 直写）无碍，较新的 filter-based MP4Box 行为随版本而异（可能告警回退 mp4，也可能直接失败）。仓库内无针对此的测试或注释；若目标 GPAC 版本严格，则所有 mp4box 路径（`--use-mp4box` 与杜比视界自动切换）都会失败。
+- **结论**：待议——先在装有 GPAC 的环境实测确认；若不兼容，让 mp4box 分支输出到 `Path.ChangeExtension(muxingPath, ".mp4")` 的临时名（保持唯一性）。
+- **状态**：⏳ 待议（第 12 轮登记）。
+
+---
+
+## RF-24：SanitizeUntrustedOptions 漏 interactive（serve 任务阻塞占死并发槽）
+
+- **位置**：`BBDown/Infrastructure/BBDownApiServer.cs:734-805`（SanitizeUntrustedOptions 未清除 `Interactive`）、`BBDown/Application/Display.cs:88`（`Console.ReadLine()`）、`Download.cs:588-591,851-854`（serve 任务流中触发）。
+- **发现**：客户端 POST `/add-task` 携带 `{"interactive":true}`，任务进入下载阶段后 `SelectTrackManually` → `Console.ReadLine` 同步阻塞。该调用不在 await 点、不可被 CancellationToken 中断，`/cancel/{id}` 无法释放它占用的并发槽；`--max-concurrent`（默认 3）个此类任务即可把并发闸门占满直至进程重启。若操作者在终端前台运行 serve，任务还会直接消费操作者的键盘输入。仅持 API 权限的本地客户端可触发（写端点 CSRF 已防护），故 Low。
+- **结论**：采纳一行修复——`SanitizeUntrustedOptions` 中加 `req.Interactive = false;`（与 `req.Debug = false` 同类处理）。
+- **状态**：⏳ 待排期（第 12 轮登记）。
+
+---
+
+## RF-25：解析失败日志 option.Url 未单行化（日志注入残留）
+
+- **位置**：`BBDown/Infrastructure/BBDownApiServer.cs:1091`、`:1120`。
+- **发现**：日志单行化机制已建（`SanitizeLogString`），但仅用于 :312 队列满路径；解析异常路径把客户端完全可控的原始 URL 直接拼进日志（`$"...{option.Url}..."`）。请求体 URL 可含 CR/LF（64KB 限额内），可伪造 `bbdown-api.log` 日志行。
+- **结论**：采纳——两处包一层 `SanitizeLogString(option.Url)`。
+- **状态**：⏳ 待排期（第 12 轮登记）。
+
+---
+
+## RF-26：Core 解析/网络健壮性低危族（5 小项）
+
+- **位置与发现**：
+  1. `BBDown.Core/Parser.cs:342-372` —— 免二压重发**失败降级**路径下，dash 无 `audio` 键 + 杜比/Hi-Res 存在时，音频在两次 pass 各追加一次且无去重（intl 分支 :229 有 Contains 去重）→ `AudioTracks` 重复条目、下游重复下载/混流。修复：pass 1 降级分支跳过重追加（`reparsePass == 0` 守卫）或补去重。
+  2. `BBDown.Core/AppHelper.cs:284` —— PGC gRPC 请求 `Host` 头硬编码 `grpc.biliapi.net`，实际目标 `app.bilibili.com`（API2），TLS SNI 与 Host 头不一致，依赖基础设施忽略 Host 路由。修复：Host 取目标 URI Authority 或移除让 HttpClient 自动生成。
+  3. `BBDown.Core/Fetcher/FavListFetcher.cs:141-157` —— pn 制收藏夹翻页无"空页/停滞"保护（MediaList/SeriesList/SpaceVideo 都有），受控响应源每页返回 code=0 且 medias 空时把 totalPage 数量的分页请求全部打完（media_count 畸形大时请求洪泛）。修复：页 medias 为空即 break。
+  4. `BBDown.Core/Fetcher/IntlBangumiInfoFetcher.cs:19` —— `.Replace("\\/", "/")` 多余（`\/` 本是合法 JSON 转义，Parse 会正确解码）且可损坏数据（原文 `\\`+`/` 被错误归并）。修复：直接删除。
+  5. `BBDown.Core/Util/SubUtil.cs:343`、`BBDown/Utilities/BBDownUtil.cs:227` —— `x/player/wbi/v2` 端点名带 wbi 却无 `w_rid/wts` 签名，当前 B 站容忍（未记录行为依赖），一旦收紧即静默降级。修复：登录路径下按现有模式补 WbiSign。
+- **结论**：采纳，随批次逐项落地（各项独立、互不依赖）。
+- **状态**：⏳ 待排期（第 12 轮登记）。
+
+---
+
+## RF-27：FindBinaries 写进程级静态工具路径（serve 并发理论面）
+
+- **位置**：`BBDown/Application/Options.cs:151-204`（经 `Workflow.cs:29` serve 下每任务调用）。
+- **发现**：`FindBinaries` 直接写进程级静态 `BBDownMuxer.FFMPEG`/`MP4BOX`/`BBDownAria2c.ARIA2C`，两个并发任务理论上可互相覆盖/静默继承。**但核实实际触发面接近零**：serve 下 `SanitizeUntrustedOptions`（BBDownApiServer.cs:737-740）已清零 `Aria2cPath`/`FFmpegPath`/`Mp4boxPath`，任务无法携带不同路径，并发探测写入的是同一 PATH 探测结果（同值无冲突）；CLI 单进程单 URL 无并发。残余仅"任务 B 静默继承任务 A 探测的路径（同机同 PATH，语义等价）"与冗余探测跳过。
+- **结论**：待议，倾向维持现状；若后续把工具路径纳入 `AppSettings`（与 Config 的 AsyncLocal 方案对齐）可顺路收编，不做预防性单独重构。
+- **状态**：⏳ 待议（第 12 轮登记）。
+
+---
+
+## RF-28：HTTP 响应体无大小上限
+
+- **位置**：`BBDown.Core/Util/HTTPUtil.cs:758`（gRPC `GetPostResponseAsync` 的 `ReadAsByteArrayAsync`）、`:467`（普通响应 `ReadAsStringAsync`）。
+- **发现**：gzip 解压侧已有 48MB 上限（AppHelper.GzipDecompress，B3-S1），但**压缩响应体本身**与普通 GET 响应体（自动解压后）均无上限。被攻破端点或 `--insecure` 中间人可用分块慢发/gzip 炸弹直接打满进程内存——与 B3 已认可的威胁模型一致，只是解压上限没有覆盖到这一层。
+- **结论**：采纳——读取前检查 `Content-Length`/逐块读取并设总量上限（如 64MB），超限抛 `InvalidDataException`。
+- **状态**：⏳ 待排期（第 12 轮登记）。
+
+---
+
+## RF-29：.editorconfig 存量违规 4 文件（BOM/末尾换行，format 门禁不覆盖）
+
+- **位置**：`BBDown.Core/BBDown.Core.csproj`（UTF-8 BOM）、`BBDown.Tests/BBDown.Tests.csproj`（UTF-8 BOM + 无末尾换行）、`.github/workflows/codeql.yml`（无末尾换行）、`.github/dependabot.yml`（无末尾换行）。均已逐字节验证。
+- **发现**：`dotnet format` 不检查 charset BOM 与 `insert_final_newline`，故 pr.yml 的 format 硬门禁拦不住。RF-8~13 涉及的源/测试文件全部干净，此为存量。
+- **结论**：采纳——按 .editorconfig 重存 4 个文件；可选补一个轻量检查（挂 format job 前置步骤）。
+- **状态**：⏳ 待排期（第 12 轮登记）。
 
 ---
 

--- a/docs/REVIEW_PLAN.md
+++ b/docs/REVIEW_PLAN.md
@@ -93,7 +93,7 @@
 
 | 项 | 级别 | 位置 | 处理 |
 |----|------|------|------|
-| H1 | High | BBDownApiServer.cs 全文件 | God 类拆 ServeSecurityMiddleware / TaskRouteMapper / TaskFileStore / CallbackGuard；SetUpServer ~200 行 lambda 内联无法单测 |
+| H1 | High | BBDownApiServer.cs 全文件 | God 类拆 ServeSecurityMiddleware / TaskRouteMapper / TaskFileStore / CallbackGuard；SetUpServer ~200 行 lambda 内联无法单测。⚠️ **第 12 轮勘误**：四个拆分文件在 git 全历史中从未存在（零提交记录），功能实际仍集中在本文件（现 1543 行）——本条记录失实，文件结构上 god 类未拆分；功能层面（中间件/持久化/回调防护）已实现并经审查通过 |
 | H2 | High | BBDownMuxer.cs:64,174 | MuxAV 20 参 / MuxByMp4box 15 参改 MuxRequest 参数对象 |
 | H3 | High | BBDownDownloadUtil.cs:28 | RangeDownloadToTmpAsync 10 参 → RangeDownloadRequest + 拆两段 |
 | H4 | High | BBDownDownloadUtil.cs:227,611 | Core 170/200 行嵌套 6-7 层：预检决策方法 + DownloadClipWithRetryAsync；6 个"检查 .tmp/.aria2"块收敛 |
@@ -188,6 +188,35 @@
 | RF-12 | ✅ `BaseUrlRegex` 收紧为 `^https?://[^/:]+:\d+`（query 中 `:数字` 不再误判为端口）；+1 测试 |
 | RF-13 | ✅ `GetWebSourceWithSetCookiesAsync`（登录轮询）改 `NoRedirectClient` 手动逐跳 + 每跳 `IsTrustedCookieHost` 校验（与 gRPC/Widevine 收口同构，凭据与响应 Set-Cookie 不外发非可信主机），上限 `MaxRedirectHops=10`；+2 测试 |
 | 基线 | ✅ dotnet build Release 0 警告 0 错误；单测 659/659 全绿（PR gate 过滤器，新增 19 例）；dotnet format --verify-no-changes 通过 |
+
+---
+
+## 第 12 轮：全库完整续审（2026-08-30）
+
+> 四路并行深查（下载管线 / serve 服务 / Core 解析网络层 / 测试与 CI 合规）+ Medium 级发现逐项人工核实。新发现 3 Medium + 16 Low + 若干 Info，**仅登记评估未修复**，全部登记 REVIEW_FINDINGS（RF-14..RF-29）；Info 级观察不登记 RF，见下表末行。
+
+| 项 | 结果 |
+|----|------|
+| 基线 | ✅ dotnet build Release 0 警告 0 错误；单测 659/659 全绿（PR gate 过滤器）；无 Skip 残留（failSkips 在位）；CI 门禁与 AGENTS.md 逐字一致；AOT source-gen JSON 四上下文覆盖完整；RF-1~RF-13 修复质量抽查通过 |
+| RF-14 (M) | 下载管线两级 catch 过滤器缺口：`NotSupportedException`（CDN 忽略 Range，BBDownDownloadUtil.cs:797 刻意抛出）/`ArgumentException`/`AggregateException` 逃逸 Download.cs:94/:1067 白名单 → 整批中止、丢 webhook/failedPages。建议 :797 改抛 InvalidOperationException + 过滤器补 AggregateException |
+| RF-15 (M) | serve 读端点无 Host 校验：默认无 token 部署下 DNS rebinding 可读 `/get-tasks*`（响应含 SavePaths 绝对路径）；写端点因 POST 必带 Origin 已受保护，读端点同源 GET 不发 Origin，须 Host 白名单收口 |
+| RF-16 (M) | 文档正确性族：wiki 退出码表虚构 2/3 且 Ctrl+C 归 0 与实现不符（实况：充电专属跳过→0、工具缺失→1、默认命令 Ctrl+C→130）；CLI-Reference 缺 --host/--ep-host/--tv-host/--area 4 项；README:333 serve 选项列举不完整 |
+| RF-17 | Parser 免二压重发两处 catch（:324/:526）吞用户取消——TaskCanceledException 无 `!token.IsCancellationRequested` 守卫，:518 注释前提错误（SendAsync 用户取消抛的正是 TaskCanceledException） |
+| RF-18 | 服务器可控 lan/audio_id 未净化直拼文件路径（SubUtil 5 处 + Parser:502 + Download:444，ResolveWorkPath 只 Combine 不过滤）；附带 SubOnly 无条件改名 .srt（ASS 内容产物扩展名错误） |
+| RF-19 | publishDate/videoDate 占位符 CurrentCulture 格式化（`:` 占位符）且替换值未过 GetValidFileName（Windows `:` ADS 陷阱/跨机路径漂移）——Program.cs:48 + PathHelper.cs:67-68 |
+| RF-20 | 跳过路径清理一致性残留：锁内权威 Skipped 分支（Download.cs:208-225）漏 coverPath；dash 跳过路径多处裸 File.Delete/Directory.Delete 与 flv 包裹版不一致（RF-8 修复族漏网） |
+| RF-21 | aria2c stdin input-file 的 URL/Cookie 未滤 `\r\n`，可注入 `all-proxy`/`dir`/新 URI 指令行（BBDownAria2c.cs:45-50） |
+| RF-22 | 进程执行边界：CheckFFmpegDOVI 探针同步阻塞 + 超时分支未观察 outTask/errTask（ExternalToolHelper.cs:26-33）；ExternalProcessRunner 成功路径 5s 管道兜底可把退出码 0 翻转为 TimeoutException（:90-92，先确认是否有意） |
+| RF-23 | 混流事务化 `.muxing-{guid}` 未知扩展名直接作为 mp4box `-new` 输出参数，GPAC 按扩展名推断容器，新版行为需实测（Download.cs:236 + BBDownMuxer.cs:184） |
+| RF-24 | SanitizeUntrustedOptions 漏 `interactive` → serve 任务阻塞 Console.ReadLine 占死并发槽且 /cancel 无法中断（一行清零修复） |
+| RF-25 | 解析失败日志两处 option.Url 未过 SanitizeLogString（BBDownApiServer.cs:1091/:1120），客户端可控 CRLF 日志注入残留 |
+| RF-26 | Core 低危族 5 小项：免二压降级音频重复追加（缺去重）、PGC gRPC Host 头与目标不符、FavList 翻页无空页保护、IntlBangumi 多余 `\/` Replace、`x/player/wbi/v2` 两处未签名（未记录行为依赖） |
+| RF-27 | FindBinaries 写进程级静态工具路径——核实 serve 下 SanitizeUntrustedOptions:737-740 已清零路径字段，覆盖场景实际不可达，倾向维持现状（待议） |
+| RF-28 | HTTP 响应体无大小上限（gRPC POST 二进制与普通响应字符串层；gzip 侧 48MB 上限未覆盖本体） |
+| RF-29 | .editorconfig 存量违规 4 文件（两个 csproj BOM、Tests csproj 与两个 github yml 缺末尾换行；format 门禁不检查 BOM/insert_final_newline）——已逐字节验证 |
+| 勘误 R-1 | 第 5 轮 H1 记录失实：ServeSecurityMiddleware/TaskRouteMapper/TaskFileStore/CallbackGuard 四文件在 git 全历史中从未存在，功能仍集中于 BBDownApiServer.cs（1543 行）；已在 H1 行加注 |
+| Info 级观察（不登记 RF） | webhook payload 页数用全量分 P 数非选中数；AddSavePath 无去重（Download.cs:211+1063 重复记录）；serve 响应缺 Cache-Control: no-store / 429 缺 Retry-After；任务持久化 tmp 固定名多实例互踩（SubscriptionStore 已用 GUID tmp 未对齐）；番剧 pub_time 无时区串按本机时区解析；HTTPUtil 重定向超限抛 HttpRequestException（StatusCode=null）命中重试谓词整流程重试；WbiSign 未按规范排序/过滤保留字符（当前可用）；TestPort.Allocate 理论 TOCTOU；Windows 哨兵 0.6s 采样窗口可能漏报进程树未杀；ClockCalibrationTests expected 基准应在调用前取；.dockerignore 未排除 .git/Tests/docs（context 偏大）；sync-wiki.ps1 未查 $LASTEXITCODE、不清理 wiki 旧页面、无 try/finally；根目录 .tmp 已被 gitignore 且未跟踪（无需处理） |
+| 无新发现面 | HttpClient 池隔离（verified/insecure×redirect/no-redirect×media 全独立）、WBI 密钥链、JsonDocument 生命周期、protobuf 帧边界、路径锁机制、LiveStreamUtil 录制循环、webhook SSRF 三重防护、持久化 tmp+flush+rename 原子性、锁序一致性、测试共享状态恢复（try/finally 快照）、Collection 序列化声明闭合、Dockerfile AOT、secrets、proto 生成纪律、serve 参数文档与代码一致性、SECURITY/CONTRIBUTING 完备性 |
 
 ---
 


### PR DESCRIPTION
## 内容

### 1. 第 12 轮完整审查登记（docs/REVIEW_FINDINGS.md + docs/REVIEW_PLAN.md）
- 四路并行深查（下载管线 / serve / Core 解析网络 / 测试与 CI 合规）+ Medium 级逐项人工核实；基线 build 0 警告 0 错误、单测 659/659 全绿
- **REVIEW_FINDINGS**：登记 RF-14~RF-29（3 Medium + 13 Low，本轮仅登记评估未修复；RF-23/RF-27 标待议），各项含位置/定性/结论/状态
  - RF-14 (M) 下载管线两级 catch 过滤器缺口（NotSupportedException/AggregateException 逃逸 → 整批中止）
  - RF-15 (M) serve 读端点无 Host 校验（DNS rebinding 可读 /get-tasks 含绝对路径）
  - RF-16 (M) 文档正确性族（wiki 退出码表虚构 2/3 等）
  - 其余 Low：取消被吞、lan 路径净化、模板日期 culture、跳过清理一致性、aria2c 注入面、serve interactive/日志注入、Core 低危族、BOM 存量等
- **REVIEW_PLAN**：新增第 12 轮记录 + 勘误第 5 轮 H1（四个拆分文件在 git 全历史中从未存在，已在行内加注）

### 2. 新增 docs/FORK_DIFFERENCES.md
- 本 fork（aliveranme）相对上游（nilaoda/BBDown）差异的实证文档：快照基准 master@11bc7fc vs 上游@259a555（领先 313 提交、221 文件 +30446/−5121）
- 基于逐项取证（merge-base、diffstat、CLI 选项逐名对比 57→72 新增 15 删除 0、上游树核查），含"上游已具备能力"澄清节（serve/AOT 上游已有）、功能/安全/工程差异、向后兼容承诺、同步上游注意事项与文档维护说明

纯文档变更，无代码影响。
