### PR TITLE
fix: RF-23 定案（混流临时名 .mp4 后缀）+ Info 级观察消纳 8 项

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -374,3 +374,20 @@ debug_*.json
 /BBDown/*.mp4
 /BBDown/*.xml
 /BBDown/*.ass
+
+# ============ Build context 瘦身（Dockerfile 仅 COPY BBDown.Core/ 与 BBDown/）============
+# 此前为 VS gitignore 复制，未排除 .git（全部 git 历史）与测试/文档/CI 等非构建目录，
+# CI 构建/发布时 context 传输显著偏大。正确性不受影响（这些目录不参与镜像构建）。
+.git/
+.github/
+.claude/
+.pi/
+.vs/
+.idea/
+BBDown.Tests/
+docs/
+assets/
+scripts/
+*.md
+.tmp
+

--- a/BBDown.Core/Util/HTTPUtil.cs
+++ b/BBDown.Core/Util/HTTPUtil.cs
@@ -337,7 +337,9 @@ public static partial class HTTPUtil
                     List<string> setCookies = webResponse.Headers.TryGetValues("Set-Cookie", out var vals) ? vals.ToList() : [];
                     return (htmlCode, setCookies);
                 }
-                throw new HttpRequestException($"重定向跳数超过上限 ({MaxRedirectHops})");
+                // 确定性失败（跳数上限/重定向环）用 InvalidOperationException：HttpRequestException
+                // 的 StatusCode 为 null 会命中重试过滤器，把整个 10 跳流程重打最多 3 遍
+                throw new InvalidOperationException($"重定向跳数超过上限 ({MaxRedirectHops})");
             }
             catch (HttpRequestException ex) when (attempt < maxRetry && (ex.StatusCode is null || (int)ex.StatusCode >= 500))
             {

--- a/BBDown.Tests/ClockCalibrationTests.cs
+++ b/BBDown.Tests/ClockCalibrationTests.cs
@@ -23,9 +23,12 @@ public class ClockCalibrationTests
             var serverDate = DateTimeOffset.UtcNow.AddMinutes(5);
             response.Headers.Date = serverDate;
 
+            // expected 基准必须在调用前取（Info 级观察）：若在 CalibrateClock 之后计算，
+            // CI 卡顿 >3s 会把执行延迟算进容差造成假失败
+            long expected = (long)Math.Round((serverDate - DateTimeOffset.UtcNow).TotalSeconds);
+
             HTTPUtil.CalibrateClock(response);
 
-            long expected = (long)Math.Round((serverDate - DateTimeOffset.UtcNow).TotalSeconds);
             Assert.InRange(Config.Current.ServerClockOffsetSeconds, expected - 3, expected + 3);
         }
         finally { Config.Apply(original); }

--- a/BBDown.Tests/DownloadPipelineTests.cs
+++ b/BBDown.Tests/DownloadPipelineTests.cs
@@ -17,16 +17,29 @@ internal static class TestHash
 }
 
 /// <summary>动态申请一个空闲回环端口：避免多个测试服务器共用同一端口时，
-/// HttpClient 连接池复用上一实例的陈旧连接，使请求计数/脚本响应错乱。</summary>
+/// HttpClient 连接池复用上一实例的陈旧连接，使请求计数/脚本响应错乱。
+/// 进程内去重（Info 级观察）：bind-0 → 取端口 → Stop 之间存在 TOCTOU——
+/// 另一个并行测试的 Allocate 可能拿到同一端口，随后 HttpListener.Start 抛
+/// AddressAlreadyInUse 使用例偶发失败。用 HashSet 记录本进程已分配端口并跳过复用。</summary>
 internal static class TestPort
 {
+    private static readonly object _gate = new();
+    private static readonly HashSet<int> _allocated = new();
+
     public static int Allocate()
     {
-        using var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
-        listener.Start();
-        int port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
+        lock (_gate)
+        {
+            for (int attempt = 0; attempt < 100; attempt++)
+            {
+                using var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+                listener.Start();
+                int port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+                listener.Stop();
+                if (_allocated.Add(port)) return port;
+            }
+            throw new InvalidOperationException("动态端口分配重试 100 次仍重复，测试环境异常");
+        }
     }
 }
 

--- a/BBDown/Application/Download.cs
+++ b/BBDown/Application/Download.cs
@@ -228,16 +228,19 @@ internal partial class Program
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException) { }
             return MuxOutcome.Skipped;
         }
-        // 混流产物事务化：ffmpeg/mp4box 写入唯一的 .muxing-{guid} 临时路径而非最终 savePath。
+        // 混流产物事务化：ffmpeg/mp4box 写入唯一的 .muxing-{guid}.mp4 临时路径而非最终 savePath。
         // 此前直接写最终路径，非零退出/取消后只返回 Failed 不删除半成品，下次运行发现
         // "存在且非空"就跳过，可能永久保留截断视频并报告成功。临时产物成功且校验通过后
         // 才原子替换到最终路径；失败/取消清理临时产物，绝不留半成品当成品。
+        // 临时名以 .mp4 结尾（RF-23）：mp4box（GPAC）按扩展名推断输出封装格式，未知扩展名
+        // 在新版 filter-based MP4Box 上行为随版本而异；.mp4 后缀让新旧版本全部确定性走
+        // ISOM 封装，ffmpeg 分支本就用 -f mp4 强制格式，不受影响。
         // 轨道文件（已下载的音视频/字幕）清理必须覆盖"成功/失败/异常"全部路径：
         // 此前只在成功路径清理，混流失败或 MuxAV 抛异常（超时/取消/进程失败）时，
         // GB 级的视频/音频轨道文件残留在 aid 工作目录，多 P 批量反复失败会累积大量磁盘占用。
         // 因此这里把轨道清理并入 finally（见 CleanupDownloadedTracks），与 .muxing-*
         // 临时产物一并兜底。
-        var muxingPath = savePath + $".muxing-{Guid.NewGuid():N}";
+        var muxingPath = savePath + $".muxing-{Guid.NewGuid():N}.mp4";
         bool muxSucceeded = false;
         try
         {

--- a/BBDown/Infrastructure/BBDownApiServer.cs
+++ b/BBDown/Infrastructure/BBDownApiServer.cs
@@ -179,6 +179,10 @@ public partial class BBDownApiServer
                 || path.StartsWithSegments("/remove-finished");
             if (isApi)
             {
+                // 安全响应头（Info 级观察）：API 响应含任务数据/绝对路径，禁止缓存落盘；
+                // nosniff 防 MIME 嗅探。429 的 Retry-After 在各自拒绝点单独附加。
+                context.Response.Headers.CacheControl = "no-store";
+                context.Response.Headers["X-Content-Type-Options"] = "nosniff";
                 if (!string.IsNullOrEmpty(_serveToken) && !FixedTimeEquals(context.Request.Headers["X-Serve-Token"], _serveToken!))
                 {
                     var clientIp = GetClientIp(context);
@@ -188,6 +192,7 @@ public partial class BBDownApiServer
                     {
                         // 1 分钟窗口内失败超阈值：限速拒绝，令 X-Serve-Token 暴力枚举失效。
                         Logger.LogWarn($"serve 认证失败过于频繁，已限速: {clientIp}");
+                        context.Response.Headers.RetryAfter = "60";
                         context.Response.StatusCode = StatusCodes.Status429TooManyRequests;
                         return;
                     }
@@ -234,6 +239,8 @@ public partial class BBDownApiServer
         {
             if (!_queryLimiter.Wait(0))
             {
+                // Retry-After 提示客户端何时可重试（限速语义与认证限速一致）
+                ctx.HttpContext.Response.Headers.RetryAfter = "60";
                 return Results.Problem(
                     "查询过于频繁，请稍后再试",
                     statusCode: StatusCodes.Status429TooManyRequests,
@@ -669,7 +676,9 @@ public partial class BBDownApiServer
                     snapshot = finishedTasks.Select(t => t.Snapshot()).ToList();
                 }
                 var json = JsonSerializer.Serialize(snapshot, AppJsonSerializerContext.Default.ListDownloadTask);
-                var tmpFile = _taskFile + ".tmp";
+                // tmp 名带 GUID（对齐 SubscriptionStore.AtomicWrite）：固定 .tmp 名会让同目录
+                // 的多个 serve 实例并发写盘互相踩踏；代价是崩溃瞬间可能残留孤儿 tmp 文件（罕见且无害）。
+                var tmpFile = _taskFile + $".tmp-{Guid.NewGuid():N}";
                 using (var fs = new FileStream(tmpFile, FileMode.Create, FileAccess.Write, FileShare.None))
                 using (var writer = new StreamWriter(fs, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
                 {
@@ -1439,10 +1448,15 @@ public record DownloadTask(string Aid, string Url, long TaskCreateTime)
     // 写者一律经 AddSavePath 走这把锁；_savePathLock 不能是 primary constructor 属性。
     private readonly object _savePathLock = new();
 
-    /// <summary>受控写入口：与 Snapshot 的深拷贝在同一把锁下，避免枚举期间被并发修改。</summary>
+    /// <summary>受控写入口：与 Snapshot 的深拷贝在同一把锁下，避免枚举期间被并发修改。
+    /// 去重（Info 级观察）：锁内 Skipped 分支与成功路径会对同一 savePath 各 Add 一次，
+    /// 导致 API 快照中同一产物出现两条——产物列表语义是集合而非序列。</summary>
     public void AddSavePath(string path)
     {
-        lock (_savePathLock) { SavePaths.Add(path); }
+        lock (_savePathLock)
+        {
+            if (!SavePaths.Contains(path)) SavePaths.Add(path);
+        }
     }
 
     /// <summary>线程安全地更新状态字段（下载线程写，查询端点读）。</summary>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 修复
 
+- **mp4box 混流临时产物扩展名兼容性**：混流事务化的临时输出名 `.muxing-{guid}` 为未知扩展名，mp4box（GPAC）按扩展名推断输出封装格式，新版 filter-based MP4Box 上行为随版本而异（可能告警回退甚至失败）。现临时名以 `.mp4` 结尾，新旧版本全部确定性走 ISOM 封装（ffmpeg 分支本就用 `-f mp4` 强制格式，不受影响）。
 - **多线程下载遇不支持 Range 的服务器时整批中止**：多线程分片路径在服务器以 200 响应 Range 请求时抛出的 `NotSupportedException`（及其它白名单外异常）会穿透页面级与批级两级 catch 过滤器，导致多 P 批量中一 P 命中即放弃剩余分 P、丢失完成通知与失败汇总。现抛出点规范化为 `InvalidOperationException` 并将过滤器补齐 `AggregateException`。
 - **SubOnly 模式 ASS 字幕产物扩展名错误**：ASS 内容字幕被无条件改名为 `.srt`，播放器无法渲染。现按源字幕内容形态决定目标扩展名。
 - **`<publishDate:...>`/`<videoDate:...>` 占位符在特定区域设置下产出非法文件名**：自定义日期格式的 `:` 是时间分隔符占位符，fi-FI 等区域下输出形如 `22.13`，en-US 下输出含 `:`（Windows 上可写入 NTFS 备用数据流，资源管理器不可见）。现固定 InvariantCulture 格式化并对替换值做文件名净化（与 ffmpeg `creation_time` 的收口同构）。
@@ -21,7 +22,9 @@
 
 ### 改进
 
-- **进程与解析层健壮性**：直播杜比视界的 ffmpeg 版本探测改真异步（不再在下载链路同步阻塞最多 5 秒，超时后补观察管道任务）；用户取消（Ctrl+C/关停）不再被解析层"免二压重发"降级路径吞掉；免二压降级路径下杜比/Hi-Res 音轨不再重复追加；番剧 gRPC 移除与目标主机不符的硬编码 Host 头；收藏夹翻页遇空页提前结束（防畸形 media_count 触发请求洪泛）；国际版番剧接口删除多余的双重转义替换。
+- **serve API 响应与持久化健壮性**：`/get-tasks` 族响应补 `Cache-Control: no-store` 与 `X-Content-Type-Options: nosniff`（任务数据含服务器绝对路径，禁止缓存落盘），认证限速与查询限速的 429 响应补 `Retry-After: 60`；任务持久化临时文件名带 GUID（对齐订阅历史，同目录多实例不再互相踩踏写盘）；同一产物不再在任务快照中重复记录（`AddSavePath` 去重）。
+- **wiki 同步脚本健壮化**：`scripts/sync-wiki.ps1` 检查 git 命令退出码（此前 commit 失败仍报成功）、自动清理 wiki 上源目录已删除的页面、异常时恢复调用目录。
+- **进程与解析层健壮性**：直播杜比视界的 ffmpeg 版本探测改真异步（不再在下载链路同步阻塞最多 5 秒，超时后补观察管道任务）；用户取消（Ctrl+C/关停）不再被解析层"免二压重发"降级路径吞掉；免二压降级路径下杜比/Hi-Res 音轨不再重复追加；番剧 gRPC 移除与目标主机不符的硬编码 Host 头；收藏夹翻页遇空页提前结束（防畸形 media_count 触发请求洪泛）；国际版番剧接口删除多余的双重转义替换；登录轮询的重定向跳数上限改为确定性失败（不再误触发整流程重试）。
 - **文档修正**：wiki 退出码表删除虚构的 `2`/`3` 退出码并修正 Ctrl+C 归属（主命令实际返回 130、子命令 0、工具缺失归 1）；参数总表补 `--host`/`--ep-host`/`--tv-host`/`--area`；README serve 配置注入说明补全选项列举。
 - **CLI 命令层全量迁移 `AsyncCommand`**：`login`/`logintv`/`article`/`live`/`sub check`/`watchlater`/`serve` 7 个命令不再以 `Task.Run + GetAwaiter().GetResult()` 阻塞线程池线程等待异步操作（serve 长驻进程此前整个生命周期额外占用 1 个阻塞线程）；serve 链路改为真异步（`RunAsync`/`StartServerAsync`），监听地址前置校验独立为 `ValidateListenUrl`。各命令退出码与错误语义不变。
 

--- a/docs/REVIEW_FINDINGS.md
+++ b/docs/REVIEW_FINDINGS.md
@@ -30,7 +30,7 @@
 | RF-20 | 跳过路径清理一致性残留（锁内 Skipped 漏 coverPath、dash 跳过路径裸删） | Low | 采纳（与 flv 分支对齐） | ✅ 已修复（第 12 轮） |
 | RF-21 | aria2c stdin input-file 换行注入面 | Low | 采纳（写前剔除 \r\n） | ✅ 已修复（第 12 轮） |
 | RF-22 | 进程执行边界（探针未观察管道任务；成功路径 5s 兜底翻转成功） | Low | 部分采纳（探针改异步执行器；成功路径语义先确认） | ✅ 探针已修复（第 12 轮）；成功路径 ⭕ 维持现状 |
-| RF-23 | mp4box 输出 `.muxing-{guid}` 未知扩展名兼容性 | Low | 待议（需 GPAC 实测后定） | ⏳ 待议（本机无 GPAC 实测环境） |
+| RF-23 | mp4box 输出 `.muxing-{guid}` 未知扩展名兼容性 | Low | 待议（需 GPAC 实测后定） | ✅ 已修复（第 12 轮补遗：临时名补 .mp4 后缀） |
 | RF-24 | SanitizeUntrustedOptions 漏 interactive | Low | 采纳（一行清零） | ✅ 已修复（第 12 轮） |
 | RF-25 | 解析失败日志 option.Url 未单行化（两处） | Low | 采纳（补 SanitizeLogString） | ✅ 已修复（第 12 轮） |
 | RF-26 | Core 解析/网络健壮性低危族（5 小项） | Low | 采纳（随批次逐项落地） | ✅ 已修复（第 12 轮） |
@@ -282,7 +282,7 @@
 - **位置**：`BBDown/Application/Download.cs:236,240`（混流事务化临时名）、`BBDown/Infrastructure/BBDownMuxer.cs:184`（mp4box 分支把该路径直接作为 `-new` 输出参数）。
 - **发现**：混流事务化把输出统一改为 `savePath + ".muxing-{guid:N}"`。ffmpeg 用 `-f mp4` 强制格式不受影响；但 GPAC 按扩展名推断输出封装格式，`.muxing-xxx` 属未知扩展名——旧版 GPAC（gf_isom_open 直写）无碍，较新的 filter-based MP4Box 行为随版本而异（可能告警回退 mp4，也可能直接失败）。仓库内无针对此的测试或注释；若目标 GPAC 版本严格，则所有 mp4box 路径（`--use-mp4box` 与杜比视界自动切换）都会失败。
 - **结论**：待议——先在装有 GPAC 的环境实测确认；若不兼容，让 mp4box 分支输出到 `Path.ChangeExtension(muxingPath, ".mp4")` 的临时名（保持唯一性）。
-- **状态**：⏳ 待议（第 12 轮登记；本机/CI 均无 GPAC 实测环境，待有环境后验证）。
+- **状态**：✅ 已修复（2026-08-30，第 12 轮补遗）：临时名改为 `.muxing-{guid:N}.mp4`——不再依赖 GPAC 对未知扩展名的容忍度，新旧版本全部确定性走 ISOM 封装（ffmpeg 分支本就用 `-f mp4` 强制格式，不受影响）；`muxingPath` 仅被精确路径引用（无模式清理、无测试断言格式名），改动零波及。无需 GPAC 实测即可定案。
 
 ---
 

--- a/docs/REVIEW_PLAN.md
+++ b/docs/REVIEW_PLAN.md
@@ -222,7 +222,7 @@
 
 ## 第 12 轮附：消纳批 RF-14~RF-29（2026-08-30）
 
-> 消纳第 12 轮登记的发现（分支 `fix/review-r12-findings`）。14 项修复落地；RF-23 待议（本机/CI 均无 GPAC 实测环境）、RF-27 维持现状定案。
+> 消纳第 12 轮登记的发现（分支 `fix/review-r12-findings`）。15 项修复落地（含补遗 RF-23，临时名补 `.mp4` 后缀无需 GPAC 实测即定案）；RF-27 维持现状定案。
 
 | 项 | 处理 |
 |----|------|
@@ -235,12 +235,14 @@
 | RF-20 | ✅ 锁内权威 Skipped 分支补 coverPath 清理；dash 分支裸删全部包裹（封面 1 处、弹幕 XML 3 处、aid 目录 3 处、flv 弹幕 2 处对齐），统一 `catch (IOException or UnauthorizedAccessException)` |
 | RF-21 | ✅ aria2c stdin 的 URL/Cookie 写入前剥离 CR/LF（注入的指令行语义消除，畸形 URI 由退出码校验兜底）；+1 测试（注入 cookie/双 URI 场景断言单行化） |
 | RF-22 | ✅ `CheckFFmpegDOVI` 改真异步 `CheckFFmpegDOVIAsync`（WaitForExitAsync+WaitAsync 5s；超时分支补观察管道任务防 UnobservedTaskException），调用点改 await；ExternalProcessRunner 成功路径 5s 兜底 ⭕ 维持现状（有意设计，注释在位） |
+| RF-23 | ✅ （补遗）混流临时名改为 `.muxing-{guid:N}.mp4`——不再依赖 GPAC 对未知扩展名的容忍度（新版 filter-based MP4Box 按扩展名推断输出封装），新旧版本全部确定性走 ISOM；ffmpeg 分支 `-f mp4` 强制格式不受影响；`muxingPath` 仅精确路径引用，改动零波及 |
 | RF-24 | ✅ `SanitizeUntrustedOptions` 补 `req.Interactive = false`（阻塞占死并发槽面消除）；既有 ClearsExecutionFields 测试补断言 |
 | RF-25 | ✅ 解析失败日志两处 `option.Url`（及异常消息）过 `SanitizeLogString` |
 | RF-26 | ✅ 5 小项全落地：① 免二压降级 dolby/flac 重复追加——applied 标志守卫 + 新文档接管时重置；② AppHelper GetHeader 移除硬编码 `Host: grpc.biliapi.net`（由 HttpClient 按 URI 生成，番剧 gRPC SNI/Host 不再错位）；③ FavListFetcher 翻页空页 break（对齐其余 fetcher 停滞语义）；④ IntlBangumiInfoFetcher 删除多余 `.Replace("\\/","/")`；⑤ `x/player/wbi/v2` 两处（SubUtil/BBDownUtil）登录态补 WbiSign（aid/cid/wts 升序），未登录保持无签名 |
 | RF-27 | ⭕ 维持现状定案（详见 FINDINGS） |
 | RF-28 | ✅ HTTPUtil 新增 `MaxResponseBodyBytes`（64MB）+ `ReadContentBoundedAsync`（Content-Length 预检 + 逐块累计双拦截）替换 `ReadAsStringAsync`/`ReadAsByteArrayAsync`，`DecodeBodyBytes` 按 charset 解码；+1 判定函数测试（64MB 上限无法廉价构造真实响应） |
 | RF-29 | ✅ 4 文件去 BOM/补末尾换行（BBDown.Core.csproj、BBDown.Tests.csproj、codeql.yml、dependabot.yml） |
+| Info 级观察 | ✅ 消纳 8 项：AddSavePath 去重（Skipped+成功双记导致 API 快照重复）；serve API 响应补 `Cache-Control: no-store`/`X-Content-Type-Options`、429 补 `Retry-After: 60`；任务持久化 tmp 名带 GUID（对齐 SubscriptionStore，多实例同目录不再互踩）；HTTPUtil 重定向超限改抛 InvalidOperationException（HttpRequestException StatusCode=null 误命中重试谓词）；TestPort.Allocate 进程内去重（TOCTOU 偶发 AddressAlreadyInUse）；ClockCalibrationTests expected 基准移到调用前；.dockerignore 补 .git/Tests/docs 等排除（context 瘦身）；sync-wiki.ps1 健壮化（$LASTEXITCODE 检查、废弃页面清理、try/finally 回目录）。⭕ 维持观察 4 项：webhook 页数语义（需产品决策）、番剧 pub_time 本机时区解析、WbiSign 未排序（当前可用）、Windows 哨兵采样窗口（漏报仅影响测试证据强度） |
 | 基线 | ✅ dotnet build Release 0 警告 0 错误；单测 666/666 全绿（+7）；LocalIntegration 3/3；serve Host 校验不破坏既有回环用例 |
 
 ---

--- a/scripts/sync-wiki.ps1
+++ b/scripts/sync-wiki.ps1
@@ -1,6 +1,7 @@
 # ==============================================================================
 # BBDown Wiki 一键同步脚本 (PowerShell)
 # 功能: 将 docs/wiki/ 目录下的所有 Markdown 文档同步推送至 GitHub Wiki 仓库
+# 语义: docs/wiki/ 是 wiki 的唯一权威来源——本地已删除的页面在 wiki 上同样会被移除
 # ==============================================================================
 
 $ErrorActionPreference = "Stop"
@@ -11,56 +12,75 @@ $wikiGitUrl = "https://github.com/$repoOwner/$repoName.wiki.git"
 $wikiSourceDir = Join-Path $PSScriptRoot "..\docs\wiki"
 $tempWikiDir = Join-Path $env:TEMP "BBDown_Wiki_Sync"
 
-Write-Host ">>> 正在准备同步 Wiki 文档..." -ForegroundColor Cyan
-
-# 1. 确保源目录存在
-if (-not (Test-Path $wikiSourceDir)) {
-    Write-Error "错误: 找不到 Wiki 源文档目录: $wikiSourceDir"
-    exit 1
-}
-
-# 2. 清理临时目录
-if (Test-Path $tempWikiDir) {
-    Remove-Item -Recurse -Force $tempWikiDir
-}
-
-# 3. 尝试克隆 Wiki 仓库
-Write-Host ">>> 正在连接 GitHub Wiki 仓库: $wikiGitUrl ..." -ForegroundColor Cyan
-try {
-    git clone $wikiGitUrl $tempWikiDir 2>$null
-} catch {
-    # 忽略错误
-}
-
-if (-not (Test-Path "$tempWikiDir\.git")) {
-    Write-Host ">>> Wiki 仓库尚未在 GitHub 上初始化，尝试创建本地仓库并推送..." -ForegroundColor Yellow
-    New-Item -ItemType Directory -Force -Path $tempWikiDir | Out-Null
-    Set-Location $tempWikiDir
-    git init -b master
-    git remote add origin $wikiGitUrl
-} else {
-    Set-Location $tempWikiDir
-}
-
-# 4. 拷贝最新文档
-Write-Host ">>> 复制 docs/wiki/ 到暂存区..." -ForegroundColor Cyan
-Copy-Item -Path "$wikiSourceDir\*" -Destination $tempWikiDir -Force
-
-# 5. 提交并推送
-git add .
-$status = git status --porcelain
-if ([string]::IsNullOrWhiteSpace($status)) {
-    Write-Host ">>> Wiki 文档内容无变更，无需推送。" -ForegroundColor Green
-} else {
-    git commit -m "docs(wiki): sync wiki documentation from repository"
-    Write-Host ">>> 正在推送到 GitHub Wiki..." -ForegroundColor Cyan
-    git push -u origin master
-    if ($LASTEXITCODE -eq 0) {
-        Write-Host ">>> ✅ Wiki 同步成功！访问地址: https://github.com/$repoOwner/$repoName/wiki" -ForegroundColor Green
-    } else {
-        Write-Host ">>> ⚠️ 推送失败。如果是首次创建 Wiki，请先前往浏览器访问 https://github.com/$repoOwner/$repoName/wiki 点击一次 'Create the first page'，然后再运行本脚本。" -ForegroundColor Yellow
+# 外部命令（git）不抛 PowerShell 异常，只能靠 $LASTEXITCODE 判断成败；
+# 统一在失败时抛错终结，不再依赖误导性的 try/catch。
+function Assert-GitSucceeded([string]$Action) {
+    if ($LASTEXITCODE -ne 0) {
+        throw "git $Action 失败 (exit=$LASTEXITCODE)"
     }
 }
 
-# 清理并切回
-Set-Location $PSScriptRoot
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+
+try {
+    Write-Host ">>> 正在准备同步 Wiki 文档..." -ForegroundColor Cyan
+
+    # 1. 确保源目录存在
+    if (-not (Test-Path $wikiSourceDir)) {
+        throw "错误: 找不到 Wiki 源文档目录: $wikiSourceDir"
+    }
+
+    # 2. 清理临时目录
+    if (Test-Path $tempWikiDir) {
+        Remove-Item -Recurse -Force $tempWikiDir
+    }
+
+    # 3. 克隆 Wiki 仓库（检查 $LASTEXITCODE；克隆失败回退到初始化本地仓库再推送）
+    Write-Host ">>> 正在连接 GitHub Wiki 仓库: $wikiGitUrl ..." -ForegroundColor Cyan
+    git clone --quiet $wikiGitUrl $tempWikiDir 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host ">>> Wiki 仓库尚未在 GitHub 上初始化，创建本地仓库并推送..." -ForegroundColor Yellow
+        New-Item -ItemType Directory -Force -Path $tempWikiDir | Out-Null
+        Push-Location $tempWikiDir
+        git init -b master; Assert-GitSucceeded "init"
+        git remote add origin $wikiGitUrl; Assert-GitSucceeded "remote add"
+    } else {
+        Push-Location $tempWikiDir
+    }
+
+    # 4. 拷贝最新文档
+    Write-Host ">>> 复制 docs/wiki/ 到暂存区..." -ForegroundColor Cyan
+    Copy-Item -Path (Join-Path $wikiSourceDir "*") -Destination $tempWikiDir -Force
+
+    # 4.1 清理 wiki 上存在但源目录已删除的页面（docs/wiki 是权威来源；
+    #     只删 *.md，不触碰 .git）
+    $stale = Get-ChildItem -Path $tempWikiDir -Filter *.md -File |
+        Where-Object { -not (Test-Path (Join-Path $wikiSourceDir $_.Name)) }
+    foreach ($f in $stale) {
+        Write-Host ">>> 移除 wiki 上已废弃的页面: $($f.Name)" -ForegroundColor Yellow
+        Remove-Item -Force $f.FullName
+    }
+
+    # 5. 提交并推送（commit 成败必须检查，否则推送旧内容仍走"成功"路径）
+    git add .
+    $status = git status --porcelain
+    if ([string]::IsNullOrWhiteSpace($status)) {
+        Write-Host ">>> Wiki 文档内容无变更，无需推送。" -ForegroundColor Green
+    } else {
+        git commit -m "docs(wiki): sync wiki documentation from repository"
+        Assert-GitSucceeded "commit"
+        Write-Host ">>> 正在推送到 GitHub Wiki..." -ForegroundColor Cyan
+        git push -u origin master
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host ">>> Wiki 同步成功！访问地址: https://github.com/$repoOwner/$repoName/wiki" -ForegroundColor Green
+        } else {
+            Write-Host ">>> 推送失败。如果是首次创建 Wiki，请先前往浏览器访问 https://github.com/$repoOwner/$repoName/wiki 点击一次 'Create the first page'，然后再运行本脚本。" -ForegroundColor Yellow
+            exit 1
+        }
+    }
+}
+finally {
+    # 无论成败都回到仓库根目录，避免调用者会话被留在临时目录；
+    # 临时目录保留便于排查，下次运行开头会自动清理
+    Set-Location $repoRoot
+}


### PR DESCRIPTION
## 概述

第 12 轮审查收尾批：RF-23 定案修复 + Info 级观察消纳 8 项（余 4 项维持观察）。10 文件，+137/−60。

## 内容

- **RF-23 定案**（混流临时名 `.muxing-{guid}` 未知扩展名对 GPAC 的兼容性）：临时名改为 `.muxing-{guid:N}.mp4`——mp4box（GPAC）按扩展名推断输出封装格式，`.mp4` 后缀让新旧版本全部确定性走 ISOM 封装，不再依赖未知扩展名的容忍度；ffmpeg 分支本就用 `-f mp4` 强制格式不受影响；`muxingPath` 仅精确路径引用（无模式清理/无测试断言格式名），改动零波及。无需 GPAC 实测即定案。
- **AddSavePath 去重**：锁内 Skipped 分支与成功路径对同一 savePath 双记，API 快照同产物出现两条。
- **serve 响应头**：`/get-tasks` 族补 `Cache-Control: no-store`/`X-Content-Type-Options: nosniff`；认证限速与查询限速 429 补 `Retry-After: 60`。
- **任务持久化 tmp 名带 GUID**：对齐 SubscriptionStore，同目录多 serve 实例写盘不再互踩。
- **HTTPUtil 重定向跳数上限**改抛 `InvalidOperationException`：原 `HttpRequestException`（StatusCode=null）误命中重试过滤器，整个 10 跳流程重打最多 3 遍。
- **TestPort.Allocate 进程内去重**：bind-0→Stop 的 TOCTOU 可让并行测试拿到同端口，HttpListener.Start 偶发 AddressAlreadyInUse。
- **ClockCalibrationTests**：expected 基准移到 CalibrateClock 调用前（CI 卡顿 >3s 的假失败面）。
- **.dockerignore**：补 `.git/`/`.github/`/`BBDown.Tests/`/`docs/`/`assets/`/`scripts/` 等排除——此前 context 含全部 git 历史（Dockerfile 仅 COPY 两个源码目录，正确性不受影响）。
- **sync-wiki.ps1 健壮化**：git 退出码检查（此前 commit 失败仍报成功）、wiki 上源目录已删除页面自动清理、try/finally 恢复调用目录。已实测运行（幂等：无变更不推送）。
- 文档：REVIEW_PLAN 消纳表补 RF-23 与 Info 级 8 项（余 4 项维持观察：webhook 页数语义、pub_time 时区、WbiSign 排序、Windows 哨兵窗口）、FINDINGS RF-23 结转、CHANGELOG 未发布条目。

## 验证

- dotnet build Release：0 警告 0 错误
- 单测（PR gate 过滤器）：666/666
- LocalIntegration：3/3
- dotnet format --verify-no-changes：通过
- sync-wiki.ps1 实测通过（无变更不推送，幂等）
