### PR TITLE
release: v1.6.17

### DIFF
--- a/BBDown/BBDown.csproj
+++ b/BBDown/BBDown.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.6.16</Version>
+    <Version>1.6.17</Version>
     <Description>BBDown是一个免费且便捷高效的哔哩哔哩下载/解析软件.</Description>
     <PackageProjectUrl>https://github.com/AliverAnme/BBDown</PackageProjectUrl>
     <StartupObject></StartupObject>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 本文件遵循 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/) 规范，版本号遵循 [Semantic Versioning](https://semver.org/lang/zh-CN/)。
 
-## [未发布]
+## [1.6.17] - 2026-08-30
 
 ### 修复
 
@@ -396,7 +396,8 @@
 
 ---
 
-[Unreleased]: https://github.com/AliverAnme/BBDown/compare/v1.6.16...HEAD
+[Unreleased]: https://github.com/AliverAnme/BBDown/compare/v1.6.17...HEAD
+[1.6.17]: https://github.com/AliverAnme/BBDown/compare/v1.6.16...v1.6.17
 [1.6.16]: https://github.com/AliverAnme/BBDown/compare/v1.6.15...v1.6.16
 [1.6.15]: https://github.com/AliverAnme/BBDown/compare/v1.6.14...v1.6.15
 [1.6.14]: https://github.com/AliverAnme/BBDown/compare/v1.6.13...v1.6.14


### PR DESCRIPTION
## 发版内容（v1.6.17）

本版本落地第 12 轮全库审查的 15 项消纳修复 + 8 项 Info 级加固，全库测试 666 例（+7）。

### 修复

- **多线程下载遇不支持 Range 的服务器时整批中止**：抛出点规范化为 `InvalidOperationException`，两级 catch 过滤器补齐 `AggregateException`（RF-14）
- **SubOnly 模式 ASS 字幕产物扩展名错误**：按源字幕内容形态决定目标扩展名（RF-18）
- **`<publishDate:...>`/`<videoDate:...>` 占位符特定区域设置下产出非法文件名**：固定 InvariantCulture + 文件名净化（RF-19）
- **重跑已下载视频时封面/装饰文件残留**：锁内权威跳过补删封面；DASH 分支裸删与 FLV 对齐包裹（RF-20）
- **serve 交互式选项占死并发槽**：serve 强制关闭 `interactive`（RF-24）
- **mp4box 混流临时产物扩展名兼容性**：临时名以 `.mp4` 结尾，新旧 GPAC 确定性走 ISOM 封装（RF-23）

### 改进

- serve API 响应补 `Cache-Control: no-store`/`nosniff`，429 补 `Retry-After: 60`；持久化 tmp 带 GUID；`AddSavePath` 去重
- 杜比视界 ffmpeg 版本探测真异步化；用户取消不再被解析层降级路径吞掉；免二压降级音轨去重；番剧 gRPC Host 头修正；收藏夹空页提前结束；登录轮询重定向超限改确定性失败
- wiki 退出码表修正（删除虚构 2/3）；参数总表补 `--host`/`--ep-host`/`--tv-host`/`--area`；README serve 选项列举补全
- `.dockerignore` 瘦身；`sync-wiki.ps1` 健壮化

### 安全性

- serve 无 token 模式 DNS rebinding 防线（Host 字面回环白名单）（RF-15）
- aria2c stdin 换行注入面收口（RF-21）
- 服务器可控 `lan`/`audio_id` 路径净化（RF-18）
- HTTP 响应体 64MB 上限（RF-28）
- serve 日志注入残留收口（RF-25）

### 测试增强

- 全库 666 例（+7）：serve Host 白名单端点/纯函数、aria2c stdin 单行化、日期占位符文化无关（fi-FI 断言）、响应体上限判定、serve Interactive 清零等
